### PR TITLE
Fix helm notes file to give correct kubernetes commands

### DIFF
--- a/.helm/data-claims-reporting-service/Chart.yaml
+++ b/.helm/data-claims-reporting-service/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0
+version: 1.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/.helm/data-claims-reporting-service/templates/NOTES.txt
+++ b/.helm/data-claims-reporting-service/templates/NOTES.txt
@@ -1,4 +1,5 @@
 {{- $namespace := .Release.Namespace }}
+{{- $releaseName := .Release.Name }}
 {{- $jobName := include "data-claims-reporting.name" . }}
 
 1. ✅ CronJob Deployed
@@ -6,7 +7,8 @@
 Your application has been deployed as a Kubernetes CronJob in the `{{ $namespace }}` namespace.
 
 To check the status of the job:
-kubectl get cronjob {{ $jobName }} --namespace {{ $namespace }}
+kubectl get cronjob {{ $releaseName }}-{{ $jobName }} --namespace {{ $namespace }}
 
 To view logs from the latest job run:
-kubectl logs --namespace {{ $namespace }} $(kubectl get pods --namespace {{ $namespace }} -l job-name={{ $jobName }} -o jsonpath="{.items[0].metadata.name}")
+kubectl logs --namespace {{ $namespace }} $( kubectl get pods --namespace {{ $namespace }} --sort-by=.metadata.creationTimestamp --no-headers |
+   grep '^{{ $releaseName }}-' | tail -n 1 | awk '{print $1}' )


### PR DESCRIPTION
## What

Fix the message when you deploy the helm chart. It now has the full cronjob name in the `get cronjob` command and the filtering now works (the job name was different every time so filtering by job field wasn't working)

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
