### PR TITLE
LPF-1327 - Remove line feed and carriage returns

### DIFF
--- a/src/main/java/uk/gov/justice/laa/dstew/claimsreports/service/CsvRowCallbackHandler.java
+++ b/src/main/java/uk/gov/justice/laa/dstew/claimsreports/service/CsvRowCallbackHandler.java
@@ -5,7 +5,6 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.Map;
-
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.RowCallbackHandler;

--- a/src/main/java/uk/gov/justice/laa/dstew/claimsreports/service/CsvRowCallbackHandler.java
+++ b/src/main/java/uk/gov/justice/laa/dstew/claimsreports/service/CsvRowCallbackHandler.java
@@ -5,6 +5,8 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.Map;
+
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.RowCallbackHandler;
 import tools.jackson.core.exc.JacksonIOException;
@@ -26,6 +28,7 @@ class CsvRowCallbackHandler implements RowCallbackHandler {
   private final int bufferFlushFrequency;
   private final CsvMapper csvMapper;
   private SequenceWriter sequenceWriter;
+  @Getter
   private int rowCount;
 
   @Override
@@ -53,7 +56,11 @@ class CsvRowCallbackHandler implements RowCallbackHandler {
       row.clear();
 
       for (int i = 1; i <= columnCount; i++) {
-        row.put(meta.getColumnName(i), resultSet.getString(i));
+        String value = resultSet.getString(i);
+        if (value != null) {
+          value = value.replace("\n", "").replace("\r", "");
+        }
+        row.put(meta.getColumnName(i), value);
       }
       sequenceWriter.write(row);
 
@@ -81,9 +88,5 @@ class CsvRowCallbackHandler implements RowCallbackHandler {
     ObjectWriter objectWriter = csvMapper.writer(schema);
     // Streaming writer that handles CSV formatting, quotations, line endings etc.
     sequenceWriter = objectWriter.writeValues(writer);
-  }
-
-  public int getRowCount() {
-    return rowCount;
   }
 }

--- a/src/test/java/uk/gov/justice/laa/dstew/claimsreports/service/CsvRowCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/justice/laa/dstew/claimsreports/service/CsvRowCallbackHandlerTest.java
@@ -188,6 +188,91 @@ public class CsvRowCallbackHandlerTest {
     verify(sequenceWriter, times(1)).write(any(Map.class));
   }
 
+  @Test
+  void willRemoveOnlyCarriageReturnCharacters() throws SQLException {
+    buildFirstRowAndSchema();
+
+    // Setup data with only carriage return characters (no line feeds)
+    setupResultSetData(2, "data\rwith\rcarriage\rreturns");
+    when(sequenceWriter.write(any(Map.class))).thenAnswer(invocation -> {
+      Map<String, String> writtenRow = invocation.getArgument(0);
+      assertEquals("datawithcarriagereturns", writtenRow.get("column_1"));
+      return null;
+    });
+
+    csvRowCallbackHandler.processRow(resultSet);
+
+    verify(sequenceWriter, times(1)).write(any(Map.class));
+  }
+
+  @Test
+  void willRemoveMultipleConsecutiveLineBreaks() throws SQLException {
+    buildFirstRowAndSchema();
+
+    // Setup data with multiple consecutive line breaks
+    setupResultSetData(2, "data\n\n\nwith\r\n\r\nmultiple\n\r\n\rbreaks");
+    when(sequenceWriter.write(any(Map.class))).thenAnswer(invocation -> {
+      Map<String, String> writtenRow = invocation.getArgument(0);
+      assertEquals("datawithmultiplebreaks", writtenRow.get("column_1"));
+      return null;
+    });
+
+    csvRowCallbackHandler.processRow(resultSet);
+
+    verify(sequenceWriter, times(1)).write(any(Map.class));
+  }
+
+  @Test
+  void willRemoveLeadingLineBreaks() throws SQLException {
+    buildFirstRowAndSchema();
+
+    // Setup data with leading line breaks
+    setupResultSetData(2, "\n\r\ndata with leading breaks");
+    when(sequenceWriter.write(any(Map.class))).thenAnswer(invocation -> {
+      Map<String, String> writtenRow = invocation.getArgument(0);
+      assertEquals("data with leading breaks", writtenRow.get("column_1"));
+      return null;
+    });
+
+    csvRowCallbackHandler.processRow(resultSet);
+
+    verify(sequenceWriter, times(1)).write(any(Map.class));
+  }
+
+  @Test
+  void willRemoveTrailingLineBreaks() throws SQLException {
+    buildFirstRowAndSchema();
+
+    // Setup data with trailing line breaks
+    setupResultSetData(2, "data with trailing breaks\n\r\n");
+    when(sequenceWriter.write(any(Map.class))).thenAnswer(invocation -> {
+      Map<String, String> writtenRow = invocation.getArgument(0);
+      assertEquals("data with trailing breaks", writtenRow.get("column_1"));
+      return null;
+    });
+
+    csvRowCallbackHandler.processRow(resultSet);
+
+    verify(sequenceWriter, times(1)).write(any(Map.class));
+  }
+
+  @Test
+  void willRemoveLeadingAndTrailingLineBreaks() throws SQLException {
+    buildFirstRowAndSchema();
+
+    // Setup data with both leading and trailing line breaks
+    setupResultSetData(2, "\r\ndata surrounded by breaks\n\r");
+    when(sequenceWriter.write(any(Map.class))).thenAnswer(invocation -> {
+      Map<String, String> writtenRow = invocation.getArgument(0);
+      assertEquals("data surrounded by breaks", writtenRow.get("column_1"));
+      return null;
+    });
+
+    csvRowCallbackHandler.processRow(resultSet);
+
+    verify(sequenceWriter, times(1)).write(any(Map.class));
+  }
+
   private void setupResultSetData(int rowNo, String data) throws SQLException {
     when(resultSet.getMetaData()).thenReturn(resultSetMetaData);
     when(resultSet.getRow()).thenReturn(rowNo);

--- a/src/test/java/uk/gov/justice/laa/dstew/claimsreports/service/CsvRowCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/justice/laa/dstew/claimsreports/service/CsvRowCallbackHandlerTest.java
@@ -171,6 +171,23 @@ public class CsvRowCallbackHandlerTest {
     assertEquals(2, csvRowCallbackHandler.getRowCount());
   }
 
+  @Test
+  void willRemoveLineFeedAndCarriageReturnFromData() throws SQLException {
+    buildFirstRowAndSchema();
+
+    // Setup data with line feed and carriage return characters
+    setupResultSetData(2, "random\ndata\r\nwith line breaks");
+    when(sequenceWriter.write(any(Map.class))).thenAnswer(invocation -> {
+      Map<String, String> writtenRow = invocation.getArgument(0);
+      assertEquals("randomdatawith line breaks", writtenRow.get("column_1"));
+      return null;
+    });
+
+    csvRowCallbackHandler.processRow(resultSet);
+
+    verify(sequenceWriter, times(1)).write(any(Map.class));
+  }
+
   private void setupResultSetData(int rowNo, String data) throws SQLException {
     when(resultSet.getMetaData()).thenReturn(resultSetMetaData);
     when(resultSet.getRow()).thenReturn(rowNo);


### PR DESCRIPTION

## What

[LPF-1327](https://dsdmoj.atlassian.net/browse/LPF-1327)

Describe what you did and why.

- Stakeholders are complaining that line feeds and carriage returns are causing inconvenience with the tools they use with our reports. They want them removed. 

- Updated CsvRowCallbackHandler to strip line feed and carriage returns from the generation code. Added a test for the callback handler to ensure it still works. REP000 tests still pass. Also refactored code to use annotation instead of a get method


## Checklist

Before you ask people to review this PR:

- [ ] Bump Helm chart version (if you have changed the Helm templates)
- [X] Tests should be passing: `./gradlew test` & `./gradlew integrationTest`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [X] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [X] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.


[LPF-1327]: https://dsdmoj.atlassian.net/browse/LPF-1327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Evidence

| File after altering code |
|------------------------|
| [report_000_2026-04-22.csv](https://github.com/user-attachments/files/26972779/report_000_2026-04-22.csv) |