### PR TITLE
LPF-1337 - fix issue where large number breaks rep013

### DIFF
--- a/src/integrationTest/java/uk/gov/justice/laa/dstew/claimsreports/IntegrationTestBase.java
+++ b/src/integrationTest/java/uk/gov/justice/laa/dstew/claimsreports/IntegrationTestBase.java
@@ -54,7 +54,7 @@ public class IntegrationTestBase {
 
   @Container
   static final LocalStackContainer localstack =
-      new LocalStackContainer(DockerImageName.parse("localstack/localstack:3.4"))
+      new LocalStackContainer(DockerImageName.parse("localstack/localstack:s3-community-archive"))
           .withServices(LocalStackContainer.Service.S3);
 
   @Autowired

--- a/src/integrationTest/java/uk/gov/justice/laa/dstew/claimsreports/sql/Report013IntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/justice/laa/dstew/claimsreports/sql/Report013IntegrationTest.java
@@ -157,6 +157,34 @@ class Report013IntegrationTest extends IntegrationTestBase {
 
   }
 
+  @Test
+  void testBiggerValues() {
+    // When
+    insertBigNumber();
+
+    List<Map<String, Object>> report013Rows = jdbcTemplate.queryForList("""
+        SELECT *
+        FROM claims.report_013
+        WHERE "Provider Office Account Number" = 'BIGONE'
+        ORDER BY "Area of Law"
+        """
+    );
+
+    // Then
+    assertThat(report013Rows).isNotEmpty();
+
+    Map<String, Object> crimeRow =
+        report013Rows.stream()
+            .filter(r -> "CRIME_LOWER".equals(r.get("Area of Law")))
+            .findFirst()
+            .orElseThrow();
+
+    assertThat(crimeRow.get("APR-2025"))
+        .isEqualTo("10000000000000000.00");
+
+  }
+
+
   private void insertAreaOfLawTestData() {
     jdbcTemplate.update("""
     INSERT INTO claims.submission (
@@ -284,6 +312,84 @@ class Report013IntegrationTest extends IntegrationTestBase {
           fee_code_description, category_of_law, total_amount
           ) VALUES ('77777777-7777-7777-7777-777777777779', '66666666-6666-6666-6666-666666666669', 'CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCC5',
               'FEE001', 'TypeA', 'integration_test_user', '2025-10-20 09:00:00+00', 'test_user', '2025-04-20 09:30:00+00', 'Description 1', 'INVEST', 1501)
+      """);
+
+    jdbcTemplate.execute("SELECT claims.refresh_report013()");
+  }
+
+  private void insertBigNumber() {
+    jdbcTemplate.update("""
+    INSERT INTO claims.submission (
+        id, bulk_submission_id, office_account_number, submission_period, area_of_law, status, crime_lower_schedule_number,
+        previous_submission_id, is_nil_submission, number_of_claims, error_messages, created_by_user_id, created_on, provider_user_id
+    ) VALUES (
+        'BBBBBBBB-B181-BBBB-BBBB-BBBBBBBBBBBB',
+        '11111111-1111-1111-1111-111111111111',
+        'BIGONE',
+        'APR-2025',
+        'Crime Lower',
+        'VALIDATION_SUCCEEDED',
+        'CSN001',
+        '22222222-2222-2222-2222-222222222222',
+        FALSE,
+        1,
+        NULL,
+        'integration_test_user',
+        '2025-11-21 05:00:00',
+        'test provider user')
+    """);
+
+    jdbcTemplate.update("""
+      INSERT INTO claims.claim (
+          id, submission_id, status, line_number, matter_type_code, created_by_user_id, created_on
+      ) VALUES (
+          'CCCCCCCC-B181-CCCC-CCCC-CCCCCCCCCCCC',
+          'BBBBBBBB-B181-BBBB-BBBB-BBBBBBBBBBBB',
+          'VALID',
+          1,
+          'MT001',
+          'integration_test_user',
+          TIMESTAMP '2025-11-21 05:00:00' - interval '1 day')
+      """);
+
+    jdbcTemplate.update("""
+    INSERT INTO claims.claim_case (
+        id, claim_id, case_id, unique_case_id, case_stage_code, stage_reached_code, outcome_code, created_by_user_id, created_on
+    ) VALUES (
+        'CC555555-B181-5555-5555-555555555555',
+        'CCCCCCCC-B181-CCCC-CCCC-CCCCCCCCCCCC',
+        'CASE002',
+        'UCASE001',
+        'STAGE1',
+        'REACHED1',
+        'SUCCESS',
+        'integration_test_user',
+        TIMESTAMP '2025-11-21 05:00:00' - interval '1 day'
+         )
+    """);
+
+
+    jdbcTemplate.update("""
+      INSERT INTO claims.claim_summary_fee (
+          id, claim_id, advice_time, travel_time, waiting_time, net_profit_costs_amount, net_disbursement_amount,
+          net_counsel_costs_amount, disbursements_vat_amount, travel_waiting_costs_amount, net_waiting_costs_amount,
+          is_vat_applicable, is_tolerance_applicable, created_by_user_id, created_on, updated_on
+      ) VALUES (
+          '66666666-B181-6666-6666-666666666666',
+          'CCCCCCCC-B181-CCCC-CCCC-CCCCCCCCCCCC',
+          60, 30, 15, 1000, 200,
+          500, 100, 50, 20,
+          TRUE, FALSE, 'integration_test_user',
+          TIMESTAMP '2025-11-21 05:00:00' - interval '2 day', TIMESTAMP '2025-11-21 05:00:00' - interval '1 day'
+           )
+      """);
+
+    jdbcTemplate.update("""
+      INSERT INTO claims.calculated_fee_detail (
+          id, claim_summary_fee_id, claim_id, fee_code, fee_type, created_by_user_id, created_on, updated_by_user_id, updated_on,
+          fee_code_description, category_of_law, total_amount
+          ) VALUES ('77777777-B181-7777-7777-777777777777', '66666666-B181-6666-6666-666666666666', 'CCCCCCCC-B181-CCCC-CCCC-CCCCCCCCCCCC',
+              'FEE001', 'TypeA', 'integration_test_user', '2025-10-20 09:00:00+00', 'test_user', '2025-04-20 09:30:00+00', 'Description 1', 'INVEST', 10000000000000000)
       """);
 
     jdbcTemplate.execute("SELECT claims.refresh_report013()");

--- a/src/main/resources/db/migration/schema/V43__rep013_handles_any_size_number.sql
+++ b/src/main/resources/db/migration/schema/V43__rep013_handles_any_size_number.sql
@@ -5,7 +5,7 @@ CREATE OR REPLACE FUNCTION claims.refresh_report013()
     VOLATILE PARALLEL UNSAFE
 AS $BODY$
 DECLARE
-column_definitions  TEXT;
+    column_definitions  TEXT;
     column_selections   TEXT;
     crosstab_columns    TEXT;
     values_clause       TEXT;
@@ -17,18 +17,18 @@ BEGIN
     -- Step 0: Detect whether we have ANY submission_period values
     --         and if not then create an empty table and exit
     --------------------------------------------------------------------
-SELECT EXISTS(
-    SELECT 1
-    FROM claims.submission AS s
-    WHERE s.status = 'VALIDATION_SUCCEEDED'
-      AND s.submission_period IS NOT NULL
-      AND claims.submission_is_not_replaced(s.id)
-      AND claims.normalise_area_of_law(s.area_of_law) IN ('CIVIL', 'CRIME LOWER', 'MEDIATION')
-) INTO report_data_exists;
+    SELECT EXISTS(
+        SELECT 1
+        FROM claims.submission AS s
+        WHERE s.status = 'VALIDATION_SUCCEEDED'
+          AND s.submission_period IS NOT NULL
+          AND claims.submission_is_not_replaced(s.id)
+          AND claims.normalise_area_of_law(s.area_of_law) IN ('CIVIL', 'CRIME LOWER', 'MEDIATION')
+    ) INTO report_data_exists;
 
-EXECUTE 'DROP TABLE IF EXISTS claims.report_013';
+    EXECUTE 'DROP TABLE IF EXISTS claims.report_013';
 
-IF NOT report_data_exists THEN
+    IF NOT report_data_exists THEN
         ----------------------------------------------------------------
         -- NO submission periods -> create an empty report table
         ----------------------------------------------------------------
@@ -40,12 +40,12 @@ IF NOT report_data_exists THEN
 
         -- No data to insert
         RETURN;
-END IF;
+    END IF;
 
     -- Step 1: Build dynamic column lists directly from subqueries
-SELECT string_agg('"' || submission_period || '" TEXT', ', ' ORDER BY year_order, month_order)
-INTO column_definitions
-FROM (
+    SELECT string_agg('"' || submission_period || '" TEXT', ', ' ORDER BY year_order, month_order)
+    INTO column_definitions
+    FROM (
          SELECT DISTINCT submission_period,
                          claims.month_order(submission_period) AS month_order,
                          SUBSTRING(submission_period, 5)::INTEGER AS year_order
@@ -56,9 +56,9 @@ FROM (
            AND claims.normalise_area_of_law(s.area_of_law) IN ('CIVIL', 'CRIME LOWER', 'MEDIATION')
      ) AS ordered_periods;
 
-SELECT string_agg('COALESCE(ROUND(p."' || submission_period || '",2)::TEXT, '''') AS "' || submission_period || '"', ', ' ORDER BY year_order, month_order)
-INTO column_selections
-FROM (
+    SELECT string_agg('COALESCE(ROUND(p."' || submission_period || '",2)::TEXT, '''') AS "' || submission_period || '"', ', ' ORDER BY year_order, month_order)
+    INTO column_selections
+    FROM (
          SELECT DISTINCT submission_period,
                          claims.month_order(submission_period) AS month_order,
                          SUBSTRING(submission_period, 5)::INTEGER AS year_order
@@ -69,9 +69,9 @@ FROM (
            AND claims.normalise_area_of_law(s.area_of_law) IN ('CIVIL', 'CRIME LOWER', 'MEDIATION')
      ) AS ordered_periods;
 
-SELECT '"' || string_agg(submission_period, '" NUMERIC(1000,2), "' ORDER BY year_order, month_order) || '" NUMERIC(1000,2)'
-INTO crosstab_columns
-FROM (
+    SELECT '"' || string_agg(submission_period, '" NUMERIC(1000,2), "' ORDER BY year_order, month_order) || '" NUMERIC(1000,2)'
+    INTO crosstab_columns
+    FROM (
          SELECT DISTINCT submission_period,
                          claims.month_order(submission_period) AS month_order,
                          SUBSTRING(submission_period, 5)::INTEGER AS year_order
@@ -82,9 +82,9 @@ FROM (
            AND claims.normalise_area_of_law(s.area_of_law) IN ('CIVIL', 'CRIME LOWER', 'MEDIATION')
      ) AS ordered_periods;
 
-SELECT 'VALUES (' || string_agg('''' || submission_period || '''', '), (' ORDER BY year_order, month_order) || ')'
-INTO values_clause
-FROM (
+    SELECT 'VALUES (' || string_agg('''' || submission_period || '''', '), (' ORDER BY year_order, month_order) || ')'
+    INTO values_clause
+    FROM (
          SELECT DISTINCT submission_period,
                          claims.month_order(submission_period) AS month_order,
                          SUBSTRING(submission_period, 5)::INTEGER AS year_order
@@ -96,14 +96,14 @@ FROM (
      ) AS ordered_periods;
 
 -- Step 2: Create the table from the latest data
-EXECUTE 'CREATE TABLE IF NOT EXISTS claims.report_013 (
+    EXECUTE 'CREATE TABLE IF NOT EXISTS claims.report_013 (
             "Provider Office Account Number" TEXT,
             "Area of Law" TEXT,
             ' || column_definitions || '
         )';
 
 -- Step 3: Build the data query
-data_query := $dq$
+    data_query := $dq$
             WITH canonical_submission AS (
                 SELECT s.id,
                        s.office_account_number,
@@ -155,15 +155,15 @@ data_query := $dq$
                 FROM canonical_submission cs
                 LEFT JOIN submission_totals st ON st.submission_id = cs.id
             )
-SELECT concat_ws('|', fa.area_of_law, fa.office_account_number),
-       fa.submission_period,
-       fa.month_total
-FROM final_aggregated fa
-ORDER BY 1,2
-    $dq$;
+    SELECT concat_ws('|', fa.area_of_law, fa.office_account_number),
+           fa.submission_period,
+           fa.month_total
+    FROM final_aggregated fa
+    ORDER BY 1,2
+        $dq$;
 
 -- Step 4: Build final INSERT
-insert_sql := 'INSERT INTO claims.report_013
+    insert_sql := 'INSERT INTO claims.report_013
             SELECT
                 split_part(p.row_id, ''|'', 2) AS "Provider Office Account Number",
                 CASE split_part(p.row_id, ''|'', 1)
@@ -178,6 +178,6 @@ insert_sql := 'INSERT INTO claims.report_013
             ) AS p(row_id TEXT, ' || crosstab_columns || ')';
 
         -- Step 6: Execute the insert
-EXECUTE insert_sql;
+    EXECUTE insert_sql;
 END
 $BODY$;

--- a/src/main/resources/db/migration/schema/V43__rep013_handles_any_size_number.sql
+++ b/src/main/resources/db/migration/schema/V43__rep013_handles_any_size_number.sql
@@ -1,0 +1,183 @@
+CREATE OR REPLACE FUNCTION claims.refresh_report013()
+    RETURNS void
+    LANGUAGE 'plpgsql'
+    COST 100
+    VOLATILE PARALLEL UNSAFE
+AS $BODY$
+DECLARE
+column_definitions  TEXT;
+    column_selections   TEXT;
+    crosstab_columns    TEXT;
+    values_clause       TEXT;
+    insert_sql          TEXT;
+    data_query          TEXT;
+    report_data_exists         BOOLEAN;
+BEGIN
+    --------------------------------------------------------------------
+    -- Step 0: Detect whether we have ANY submission_period values
+    --         and if not then create an empty table and exit
+    --------------------------------------------------------------------
+SELECT EXISTS(
+    SELECT 1
+    FROM claims.submission AS s
+    WHERE s.status = 'VALIDATION_SUCCEEDED'
+      AND s.submission_period IS NOT NULL
+      AND claims.submission_is_not_replaced(s.id)
+      AND claims.normalise_area_of_law(s.area_of_law) IN ('CIVIL', 'CRIME LOWER', 'MEDIATION')
+) INTO report_data_exists;
+
+EXECUTE 'DROP TABLE IF EXISTS claims.report_013';
+
+IF NOT report_data_exists THEN
+        ----------------------------------------------------------------
+        -- NO submission periods -> create an empty report table
+        ----------------------------------------------------------------
+        EXECUTE '
+            CREATE TABLE claims.report_013 (
+                "Provider Office Account Number" TEXT,
+                "Area of Law" TEXT
+            )';
+
+        -- No data to insert
+        RETURN;
+END IF;
+
+    -- Step 1: Build dynamic column lists directly from subqueries
+SELECT string_agg('"' || submission_period || '" TEXT', ', ' ORDER BY year_order, month_order)
+INTO column_definitions
+FROM (
+         SELECT DISTINCT submission_period,
+                         claims.month_order(submission_period) AS month_order,
+                         SUBSTRING(submission_period, 5)::INTEGER AS year_order
+         FROM claims.submission AS s
+         WHERE s.status = 'VALIDATION_SUCCEEDED'
+           AND s.submission_period IS NOT NULL
+           AND claims.submission_is_not_replaced(s.id)
+           AND claims.normalise_area_of_law(s.area_of_law) IN ('CIVIL', 'CRIME LOWER', 'MEDIATION')
+     ) AS ordered_periods;
+
+SELECT string_agg('COALESCE(ROUND(p."' || submission_period || '",2)::TEXT, '''') AS "' || submission_period || '"', ', ' ORDER BY year_order, month_order)
+INTO column_selections
+FROM (
+         SELECT DISTINCT submission_period,
+                         claims.month_order(submission_period) AS month_order,
+                         SUBSTRING(submission_period, 5)::INTEGER AS year_order
+         FROM claims.submission AS s
+         WHERE s.status = 'VALIDATION_SUCCEEDED'
+           AND s.submission_period IS NOT NULL
+           AND claims.submission_is_not_replaced(s.id)
+           AND claims.normalise_area_of_law(s.area_of_law) IN ('CIVIL', 'CRIME LOWER', 'MEDIATION')
+     ) AS ordered_periods;
+
+SELECT '"' || string_agg(submission_period, '" NUMERIC(1000,2), "' ORDER BY year_order, month_order) || '" NUMERIC(1000,2)'
+INTO crosstab_columns
+FROM (
+         SELECT DISTINCT submission_period,
+                         claims.month_order(submission_period) AS month_order,
+                         SUBSTRING(submission_period, 5)::INTEGER AS year_order
+         FROM claims.submission AS s
+         WHERE s.status = 'VALIDATION_SUCCEEDED'
+           AND s.submission_period IS NOT NULL
+           AND claims.submission_is_not_replaced(s.id)
+           AND claims.normalise_area_of_law(s.area_of_law) IN ('CIVIL', 'CRIME LOWER', 'MEDIATION')
+     ) AS ordered_periods;
+
+SELECT 'VALUES (' || string_agg('''' || submission_period || '''', '), (' ORDER BY year_order, month_order) || ')'
+INTO values_clause
+FROM (
+         SELECT DISTINCT submission_period,
+                         claims.month_order(submission_period) AS month_order,
+                         SUBSTRING(submission_period, 5)::INTEGER AS year_order
+         FROM claims.submission AS s
+         WHERE s.status = 'VALIDATION_SUCCEEDED'
+           AND s.submission_period IS NOT NULL
+           AND claims.submission_is_not_replaced(s.id)
+           AND claims.normalise_area_of_law(s.area_of_law) IN ('CIVIL', 'CRIME LOWER', 'MEDIATION')
+     ) AS ordered_periods;
+
+-- Step 2: Create the table from the latest data
+EXECUTE 'CREATE TABLE IF NOT EXISTS claims.report_013 (
+            "Provider Office Account Number" TEXT,
+            "Area of Law" TEXT,
+            ' || column_definitions || '
+        )';
+
+-- Step 3: Build the data query
+data_query := $dq$
+            WITH canonical_submission AS (
+                SELECT s.id,
+                       s.office_account_number,
+                       claims.normalise_area_of_law(s.area_of_law) AS area_of_law,
+                       s.is_nil_submission,
+                       s.submission_period
+                FROM claims.submission AS s
+                WHERE s.status = 'VALIDATION_SUCCEEDED'
+                  AND claims.submission_is_not_replaced(s.id)
+                  AND claims.normalise_area_of_law(s.area_of_law) IN ('CIVIL', 'CRIME LOWER', 'MEDIATION')
+                ),
+            claim_totals AS (
+                SELECT c.submission_id,
+                       c.id AS claim_id,
+                       CASE
+                           WHEN a_latest.claim_id IS NULL THEN COALESCE(SUM(cf.total_amount), 0)
+                           ELSE COALESCE(MAX(a_latest.allowed_total_incl_vat), 0)
+                       END AS claim_amount
+                FROM canonical_submission cs
+                JOIN claims.claim c
+                  ON c.submission_id = cs.id AND c.status IN ('VOID', 'VALID')
+                LEFT JOIN claims.calculated_fee_detail cf
+                  ON cf.claim_id = c.id
+                LEFT JOIN LATERAL (
+                    SELECT a.claim_id,
+                           a.allowed_total_incl_vat
+                    FROM claims.assessment a
+                    WHERE a.claim_id = c.id
+                    ORDER BY a.created_on DESC NULLS LAST
+                    LIMIT 1
+                ) a_latest ON true
+                GROUP BY c.submission_id, c.id, a_latest.claim_id
+            ),
+            submission_totals AS (
+                SELECT cs.id AS submission_id,
+                       SUM(ct.claim_amount) AS total_amount
+                FROM canonical_submission cs
+                LEFT JOIN claim_totals ct
+                  ON ct.submission_id = cs.id
+                GROUP BY cs.id
+            ),
+            final_aggregated AS (
+                SELECT cs.office_account_number,
+                       cs.area_of_law,
+                       cs.submission_period,
+                       CASE WHEN cs.is_nil_submission THEN ROUND(0::numeric,2)
+                            ELSE ROUND(COALESCE(st.total_amount,0),2)
+                       END AS month_total
+                FROM canonical_submission cs
+                LEFT JOIN submission_totals st ON st.submission_id = cs.id
+            )
+SELECT concat_ws('|', fa.area_of_law, fa.office_account_number),
+       fa.submission_period,
+       fa.month_total
+FROM final_aggregated fa
+ORDER BY 1,2
+    $dq$;
+
+-- Step 4: Build final INSERT
+insert_sql := 'INSERT INTO claims.report_013
+            SELECT
+                split_part(p.row_id, ''|'', 2) AS "Provider Office Account Number",
+                CASE split_part(p.row_id, ''|'', 1)
+                    WHEN ''CIVIL'' THEN ''LEGAL_HELP''
+                    WHEN ''CRIME LOWER'' THEN ''CRIME_LOWER''
+                    ELSE split_part(p.row_id, ''|'', 1)
+                END AS "Area of Law",
+                ' || column_selections || '
+            FROM claims.crosstab(
+                ' || quote_literal(data_query) || ',
+                ' || quote_literal(values_clause) || '
+            ) AS p(row_id TEXT, ' || crosstab_columns || ')';
+
+        -- Step 6: Execute the insert
+EXECUTE insert_sql;
+END
+$BODY$;


### PR DESCRIPTION
## What

[Link to ticket](https://dsdmoj.atlassian.net/browse/LPF-1337)

- We should handle whatever values are sent to us via Data Stewardship
- In this case they sent us a very big value, and REP013 didn't like it.
- Tweak REP013 so it can handle any number Postgres can, while still doing rounding to 2DP as currency value
- Use `community-archive` of localstack to avoid licensing issues causing flaky behaviour
<img width="989" height="450" alt="image" src="https://github.com/user-attachments/assets/a6592d03-3620-4080-b926-0e21990deaa4" />

## Checklist

Before you ask people to review this PR:

- [ ] Bump Helm chart version (if you have changed the Helm templates)
- [x] Tests should be passing: `./gradlew test` & `./gradlew integrationTest`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
