### PR TITLE
LPF-1339: Add indexes across multiple tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ out/
 
 ### VS Code ###
 .vscode/
+bin/

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,9 +20,7 @@ spring:
 
 logging:
   level:
-    org.flywaydb: WARN
-    org.flywaydb.core.internal.sqlscript: ERROR
-    org.flywaydb.core.internal.command.DbMigrate: ERROR
+    org.flywaydb: INFO
 
 # used by actuator info endpoint
 info:

--- a/src/main/resources/db/migration/schema/V45__rep000_create_index_claim_submission_status.sql
+++ b/src/main/resources/db/migration/schema/V45__rep000_create_index_claim_submission_status.sql
@@ -1,0 +1,3 @@
+-- Faster submission → claim JOIN and status filtering
+CREATE INDEX IF NOT EXISTS idx_claim_submission_status
+ON claims.claim (submission_id, status);

--- a/src/main/resources/db/migration/schema/V46__rep000_create_index_assessment_claim_created_desc.sql
+++ b/src/main/resources/db/migration/schema/V46__rep000_create_index_assessment_claim_created_desc.sql
@@ -1,0 +1,3 @@
+-- Supports lateral lookup for latest assessment per claim. Prevents scanning of the whole assessment table
+CREATE INDEX IF NOT EXISTS idx_assessment_claim_created_desc
+ON claims.assessment (claim_id, created_on DESC);

--- a/src/main/resources/db/migration/schema/V47__rep000_create_index_cfd_claim_updated_desc.sql
+++ b/src/main/resources/db/migration/schema/V47__rep000_create_index_cfd_claim_updated_desc.sql
@@ -1,0 +1,3 @@
+-- Supports lateral lookup for latest calculated fee detail per claim
+CREATE INDEX IF NOT EXISTS idx_cfd_claim_updated_desc
+ON claims.calculated_fee_detail (claim_id, updated_on DESC, created_on DESC);

--- a/src/main/resources/db/migration/schema/V48__rep000_create_index_bulk_submission_created.sql
+++ b/src/main/resources/db/migration/schema/V48__rep000_create_index_bulk_submission_created.sql
@@ -1,0 +1,3 @@
+-- Speeds up the 3-year filter on bulk submissions
+CREATE INDEX IF NOT EXISTS idx_bulk_submission_created
+ON claims.bulk_submission (created_on);


### PR DESCRIPTION
## What

[Link to ticket](https://dsdmoj.atlassian.net/browse/LPF-1339)

Create indexes for several tables. Have split into separate migrations to make testing easier. Have not chosen to run concurrently - this was causing issues and creating some unpredictable behaviour where the index creation was waiting to begin, causing migration to hang indefinitely.

Will likely need to merge this out of hours and check indexes are created successfully in prod. Not sure how long they might take in prod, and table writes will be locked whilst the indexes are being created. 

## Checklist

Before you ask people to review this PR:

- [ ] Bump Helm chart version (if you have changed the Helm templates)
- [ ] Tests should be passing: `./gradlew test` & `./gradlew integrationTest`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
