### PR TITLE
Readme badge update

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,5 +106,4 @@ When enabled it will attempt to upload the report to the `reports/errors` folder
 You should not turn this on permanently it is intended as just a debug helper.  
 
 ### Pre commit hooks
-
 Pre commit hooks have been set up on this repository to ensure no accidental commits of secrets, keys etc. Provided by DevSecOps https://github.com/ministryofjustice/devsecops-hooks

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # laa-data-claims-reporting-service
-[![Ministry of Justice Repository Compliance Badge](https://github-community.service.justice.gov.uk/repository-standards/api/laa-data-claims-reporting-service/badge)](https://github-community.service.justice.gov.uk/repository-standards/laa-data-claims-reporting-service)
+[![Ministry of Justice Repository Compliance Badge](https://github-community.service.justice.gov.uk/repository-standards/api/laa-data-claims-reporting-service/badge?v=2)](https://github-community.service.justice.gov.uk/repository-standards/laa-data-claims-reporting-service)
 
 This is a Java based Spring Boot application hosted on [MOJ Cloud Platform](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/concepts/what-is-the-cloud-platform.html).
 
@@ -106,4 +106,5 @@ When enabled it will attempt to upload the report to the `reports/errors` folder
 You should not turn this on permanently it is intended as just a debug helper.  
 
 ### Pre commit hooks
+
 Pre commit hooks have been set up on this repository to ensure no accidental commits of secrets, keys etc. Provided by DevSecOps https://github.com/ministryofjustice/devsecops-hooks


### PR DESCRIPTION
## What

NO TICKET

Noticed MOJ compliance badge was stuck on Standard eventhough the repo is classed as Exemplar, added meaningless query param to url to force a refresh on the fetch

## Checklist

Before you ask people to review this PR:

- [ ] Bump Helm chart version (if you have changed the Helm templates)
- [ ] Tests should be passing: `./gradlew test` & `./gradlew integrationTest`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
