### PR TITLE
LPF-1352: Add structured logging

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -2,4 +2,25 @@
 version: v1.25.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
+  SNYK-JAVA-TOOLSJACKSONCORE-15907550:
+    - '*':
+        reason: Issue with Json parser we don't use, so wait for Spring to catch up with fix
+        expires: 2026-05-08T00:00:00.000Z
+        created: 2026-04-08T00:00:00.000Z
+  SNYK-JAVA-ORGAPACHETOMCATEMBED-15989820:
+    - '*':
+        reason: >-
+          Tomcat version managed by LAA Spring Boot plugin. 
+          Not using CLIENT_CERT authentication where vulnerability applies.
+          Will be fixed when plugin updates dependency.
+        expires: 2026-06-13T00:00:00.000Z
+        created: 2026-04-13T00:00:00.000Z
+  SNYK-JAVA-ORGAPACHETOMCATEMBED-16643259:
+    - '*':
+        reason: >-
+          Tomcat version managed by LAA Spring Boot plugin.
+          Allocation of Resources vulnerability not applicable to our use case.
+          Will be fixed when plugin updates dependency.
+        expires: 2026-06-30T00:00:00.000Z
+        created: 2026-05-13T00:00:00.000Z
 patch: {}

--- a/README.md
+++ b/README.md
@@ -33,6 +33,79 @@ Includes the following subprojects:
 
 `./gradlew integrationTest`
 
+## Logging
+
+This application uses **ECS (Elastic Common Schema) structured logging** for production environments and console logging for local development.
+
+### Structured Logging (Default/Production)
+
+By default, the application outputs logs in ECS JSON format with distributed tracing support:
+
+```json
+{
+  "@timestamp": "2026-05-11T16:25:18.992904Z",
+  "ecs": {
+    "version": "8.11"
+  },
+  "log": {
+    "level": "INFO",
+    "logger": "uk.gov.justice.laa.dstew.claimsreports.runner.ClaimsReportingServiceRunner"
+  },
+  "message": "Generated REPXXX report with 1234 rows",
+  "process": {
+    "pid": 1,
+    "thread": {
+      "name": "main"
+    }
+  },
+  "service": {
+    "environment": "staging",
+    "name": "LAA Claims Data Reporting Service",
+    "node": {
+      "name": "laa-data-claims-reporting-service-xxxxx"
+    },
+    "version": "1.0.0"
+  },
+  "spanId": "fe4586c5fd5f7021",
+  "traceId": "69aaffee8d19869cfe4586c5fd5f7021"
+}
+```
+
+**Key fields:**
+- `@timestamp`: ISO 8601 timestamp
+- `log.level`: Log level (INFO, DEBUG, WARN, ERROR)
+- `message`: Log message
+- `service.name`: Application name from spring.application.name
+- `service.version`: Application version from gradle.properties
+- `service.environment`: Active Spring profile
+- `service.node.name`: Hostname (pod name in Kubernetes)
+- `traceId` / `spanId`: Distributed tracing correlation IDs
+
+### Local Development Logging
+
+When running with the `local` profile (e.g., `./gradlew bootRun`), logs use a human-readable console format:
+
+```
+2026-05-11T16:25:18.992+01:00 [main] [69aaffee8d19869cfe4586c5fd5f7021/fe4586c5fd5f7021] INFO  u.g.j.l.d.c.runner.ClaimsReportingServiceRunner - Starting claims report generation
+```
+
+This format includes trace/span IDs for correlation while remaining easy to read during development.
+
+### Log Level Configuration
+
+Log levels can be controlled via environment variables:
+
+- `ROOT_LOGGING_LEVEL`: Root logger level (default: info)
+- `SPRING_LOGGING_LEVEL`: Spring framework logger level (default: info)
+- `APP_LOGGING_LEVEL`: Application package logger level (default: info)
+
+Example:
+```bash
+export ROOT_LOGGING_LEVEL=debug
+export APP_LOGGING_LEVEL=trace
+./gradlew bootRun
+```
+
 ### Run locally using Minikube
 ```
 brew install minikube

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ By default, the application outputs logs in ECS JSON format with distributed tra
   },
   "service": {
     "environment": "staging",
-    "name": "LAA Claims Data Reporting Service",
+    "name": "LAA Claims Data Reporting Application",
     "node": {
       "name": "laa-data-claims-reporting-service-xxxxx"
     },
@@ -90,21 +90,6 @@ When running with the `local` profile, logs use a human-readable console format:
 ```
 
 This format includes trace/span IDs for correlation while remaining easy to read during development.
-
-### Log Level Configuration
-
-Log levels can be controlled via environment variables:
-
-- `ROOT_LOGGING_LEVEL`: Root logger level (default: info)
-- `SPRING_LOGGING_LEVEL`: Spring framework logger level (default: info)
-- `APP_LOGGING_LEVEL`: Application package logger level (default: info)
-
-Example:
-```bash
-export ROOT_LOGGING_LEVEL=debug
-export APP_LOGGING_LEVEL=trace
-./gradlew bootRun
-```
 
 ### Run locally using Minikube
 ```

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ By default, the application outputs logs in ECS JSON format with distributed tra
 
 ### Local Development Logging
 
-When running with the `local` profile (e.g., `./gradlew bootRun`), logs use a human-readable console format:
+When running with the `local` profile, logs use a human-readable console format:
 
 ```
 2026-05-11T16:25:18.992+01:00 [main] [69aaffee8d19869cfe4586c5fd5f7021/fe4586c5fd5f7021] INFO  u.g.j.l.d.c.runner.ClaimsReportingServiceRunner - Starting claims report generation

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,15 @@ bootRun {
     systemProperty "spring.profiles.active", "local"
 }
 
+processResources {
+    filteringCharset = 'UTF-8'
+    filesMatching('**/application*.yml') {
+        filter(org.apache.tools.ant.filters.ReplaceTokens, tokens: [
+            version: project.version.toString()
+        ], beginToken: '@', endToken: '@')
+    }
+}
+
 jacocoTestReport {
     afterEvaluate {
         classDirectories.setFrom(files(classDirectories.files.collect {
@@ -54,6 +63,10 @@ dependencies {
 
     implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation 'io.prometheus:prometheus-metrics-exporter-pushgateway'
+
+    // Required for tracing information
+    implementation 'org.springframework.boot:spring-boot-micrometer-tracing-brave'
+    implementation 'io.micrometer:micrometer-tracing-bridge-brave'
 
     implementation 'tools.jackson.dataformat:jackson-dataformat-csv:3.1.3'
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -3,6 +3,11 @@ spring:
     locations:
       - classpath:db/migration/schema
       - classpath:db/migration/localtestdata
+
+# Override for local development - use readable console logs with trace IDs
+logging:
+  pattern:
+    console: "%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX} [%thread] [%X{traceId}/%X{spanId}] %-5level %logger{36} - %msg%n"
 aws:
   accessKeyId: test
   secretAccessKey: test

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -6,6 +6,9 @@ spring:
 
 # Override for local development - use readable console logs with trace IDs
 logging:
+  structured:
+    format:
+      console: ''
   pattern:
     console: "%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX} [%thread] [%X{traceId}/%X{spanId}] %-5level %logger{36} - %msg%n"
 aws:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,7 @@
 spring:
   application:
     name: LAA Claims Data Reporting Application
+    version: @version@
   # Default connection details for local dev, overridden in other envs
   datasource:
     driver-class-name: org.postgresql.Driver
@@ -18,9 +19,22 @@ spring:
       replication_source_db_url: "replication_source_db_url"
       replication_source_db_name: "replication_source_db_name"
 
+# ECS structured logging
 logging:
   level:
+    root: ${ROOT_LOGGING_LEVEL:info}
+    org.springframework: ${SPRING_LOGGING_LEVEL:info}
+    uk.gov.justice.laa.dstew.claimsreports: ${APP_LOGGING_LEVEL:info}
     org.flywaydb: INFO
+  structured:
+    format:
+      console: ecs
+    ecs:
+      service:
+        name: ${spring.application.name:default}
+        version: ${spring.application.version:default}
+        environment: ${spring.profiles.active:default}
+        node_name: ${HOSTNAME:unknown}
 
 # used by actuator info endpoint
 info:


### PR DESCRIPTION
## What

[Link to ticket](https://dsdmoj.atlassian.net/browse/LPF-1352)

Add structured ECS logging to DCRS. Add trace IDs and span IDs to make related log lines more identifiable. This work makes logs machine readable in Elasticsearch and easier to monitor via tools like OpenSearch, Kibana etc.

Also, override the local set up with a more human readable structure for easier local debugging. 

## Checklist

Before you ask people to review this PR:

- [ ] Bump Helm chart version (if you have changed the Helm templates)
- [ ] Tests should be passing: `./gradlew test` & `./gradlew integrationTest`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
