### PR TITLE
fix(LPF-1378): remove commit message enforcement

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,12 +8,3 @@ repos:
     rev: 772d7ffaeee5d611a904cc564a3fe3c7ad927635 #v3.2.0
     hooks:
       - id: conventional-pre-commit
-
-  - repo: local
-    hooks:
-      - id: valid-commit-format
-        name: Validate commit message format (with ticket ID)
-        entry:
-          bash -c 'grep -Eq "^(feat|fix|docs|chore|refactor|test|ci|build|perf)(\([A-Z]+-[0-9]+\))?: .+" <<< "$(cat "$1")"'
-        language: system
-        stages: [ commit-msg ]

--- a/README.md
+++ b/README.md
@@ -275,9 +275,8 @@ You should not turn this on permanently it is intended as just a debug helper.
 
 ## Pre commit hooks
 - Pre commit hooks have been set up on this repository to ensure no accidental commits of secrets, keys etc. Provided by DevSecOps https://github.com/ministryofjustice/devsecops-hooks
-- Pre commit hooks have been set up to ensure commit messages follow the correct format for release-please, which automates our releases. See the [Releases](#releases) section for more details.
 
-Install both hooks with the following command:
+Install the hook with the following command:
 ```text
 pre-commit install
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     implementation(platform("io.netty:netty-codec-compression:4.2.13.Final"))
     implementation(platform("io.netty:netty-codec-http2:4.2.13.Final"))
     implementation(platform("io.netty:netty-transport-classes-epoll:4.2.13.Final"))
+    implementation(platform("io.netty:netty-codec-http:4.2.13.Final"))
 
     // Resolve snyk scan
     implementation 'org.apache.tomcat.embed:tomcat-embed-core:11.0.22'


### PR DESCRIPTION
## What

[LPF-1378](https://dsdmoj.atlassian.net/browse/LPF-1378)

Removed the pre-commit hook that enforces local commit messages to be in a certain format. 
Updated README to reflect the change. 

## Evidence
- Attach any screenshots of a manual test or logs, or link to successful deployment
- Before & after the change if possible

## Checklist

Before you ask people to review this PR:

- [X] Title follows the format `{type}({TICKET-NUMBER}): {brief description}`.   Example: `feat(ABC-123): add caching layer`
    - Type must be one of:
        - feat
        - fix
        - docs
        - chore
        - refactor
        - test
        - ci
        - build
        - perf
- [ ] Bump Helm chart version (if you have changed the Helm templates)
- [x] Tests should be passing: `./gradlew test` & `./gradlew integrationTest`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.


[LPF-1378]: https://dsdmoj.atlassian.net/browse/LPF-1378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ