### PR TITLE
chore: update regex validation for PR titles to allow breaking changes

### DIFF
--- a/.github/workflows/pr-title-validation.yml
+++ b/.github/workflows/pr-title-validation.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Checking PR title: $TITLE"
 
           if echo "$TITLE" | grep -Eq \
-            '^(feat|fix|docs|refactor|test|ci|build|perf)\([A-Z]+-[0-9]+\): .+|^chore(.+): .+'; then
+            '^((feat|fix|docs|refactor|test|ci|build|perf)\([A-Z]+-[0-9]+\)!?: .+)$|^chore(.*): .+$'; then
             echo "✅ PR title format is valid"
           else
             echo "❌ Invalid PR title format"


### PR DESCRIPTION
## What

[N/A](https://dsdmoj.atlassian.net/browse/LPF-XXX)

Tweak regex validation done on PR titles to allow
a) breaking changes to be flagged - this means we can use the Release Please major version update increment feature
b) chores to avoid the optional context - we use this context for ticket number usually, but most chores do not have tickets - this stops us having to force in LPF-000 when we want to fix say Snyk issues, while still enforcing the context for other types - we should not be doing features, bug fixes, refactors without tickets.

## Evidence
1. <img width="726" height="386" alt="image" src="https://github.com/user-attachments/assets/ebcb0323-32c0-4456-9f27-2722208aea8d" />
2. This PR title passes validation.

## Checklist

Before you ask people to review this PR:

- [x] Title follows the format `{type}({TICKET-NUMBER}): {brief description}`.   Example: `feat(ABC-123): add caching layer`
    - Type must be one of:
        - feat
        - fix
        - docs
        - chore
        - refactor
        - test
        - ci
        - build
        - perf
- [ ] Bump Helm chart version (if you have changed the Helm templates)
- [x] Tests should be passing: `./gradlew test` & `./gradlew integrationTest`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
