### PR TITLE
ci(LPF-1444): alert on job failure

### DIFF
--- a/.helm/data-claims-reporting-service/Chart.yaml
+++ b/.helm/data-claims-reporting-service/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.2
+version: 1.4.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/.helm/data-claims-reporting-service/templates/prometheus-rules.yaml
+++ b/.helm/data-claims-reporting-service/templates/prometheus-rules.yaml
@@ -67,6 +67,25 @@ spec:
           for: 0m
           labels:
             severity: {{ .Values.alerting.severity }}
+        - alert: KubeJobFailed
+          annotations:
+            message: Job has failed to run
+            runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/blob/master/runbook.md#alert-name-kubejobfailed
+            dashboard_url: {{ .Values.alerting.grafanaDashboard }}
+          expr: |-
+            max_over_time(kube_job_status_failed{namespace="{{ .Release.Namespace }}"}[2h]) * on(job_name, namespace)group_left()(time() - kube_job_created < 24 * 3600) > 0
+          for: 1m
+          labels:
+            severity: {{ .Values.alerting.severity }}
+        - alert: KubeJobNotCreated
+          annotations:
+            message: Job has failed to be created
+            dashboard_url: {{ .Values.alerting.grafanaDashboard }}
+          expr: |-
+            count(kube_job_created{namespace="{{ .Release.Namespace }}"} and (time() - kube_job_created < 24 * 3600))
+          for: 1m
+          labels:
+            severity: {{ .Values.alerting.severity }}
     - name: application-rules
       rules:
         - alert: reportFailed
@@ -118,4 +137,4 @@ spec:
           for: 1m
           labels:
             severity: {{ .Values.alerting.severity }}
-  {{- end }}
+{{- end }}


### PR DESCRIPTION
## What

[LPF-1444](https://dsdmoj.atlassian.net/browse/LPF-1444)

Add alerts for 
a) There are jobs that have ended up in the "failed status" in the past 24 hours
b) There were no jobs created in the past 24 hours

They are both timeboxed as jobs are ephemeral. Lets say Job A fails. And within a few hours we fix the problem that caused Job A to fail. Job A will always be failed, it will never not be failed. And that is fine, we don't care. But we don't want the alert to stay sitting in the alert list forever. So only caring about "today's failures" solves that

## Evidence
- N/A yet. Attempt to test without deploying to main doesn't work.

## Checklist

Before you ask people to review this PR:

- [x] Title follows the format `{type}({TICKET-NUMBER}): {brief description}`.   Example: `feat(ABC-123): add caching layer`
    - Type must be one of:
        - feat
        - fix
        - docs
        - chore
        - refactor
        - test
        - ci
        - build
        - perf
- [x] Bump Helm chart version (if you have changed the Helm templates)
- [x] Tests should be passing: `./gradlew test` & `./gradlew integrationTest`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.


[LPF-1444]: https://dsdmoj.atlassian.net/browse/LPF-1444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ