### PR TITLE
ci(LPF-1444): Tweak alerts to be more accurate

### DIFF
--- a/.helm/data-claims-reporting-service/Chart.yaml
+++ b/.helm/data-claims-reporting-service/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.3
+version: 1.4.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/.helm/data-claims-reporting-service/templates/prometheus-rules.yaml
+++ b/.helm/data-claims-reporting-service/templates/prometheus-rules.yaml
@@ -73,7 +73,8 @@ spec:
             runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/blob/master/runbook.md#alert-name-kubejobfailed
             dashboard_url: {{ .Values.alerting.grafanaDashboard }}
           expr: |-
-            max_over_time(kube_job_status_failed{namespace="{{ .Release.Namespace }}"}[2h]) * on(job_name, namespace)group_left()(time() - kube_job_created < 24 * 3600) > 0
+            max by (job_name, namespace) (max_over_time(kube_job_status_failed{namespace="{{ .Release.Namespace }}"}[2h]))
+            * on (job_name, namespace) (time() - kube_job_created < 24 * 3600) > 0
           for: 1m
           labels:
             severity: {{ .Values.alerting.severity }}

--- a/.helm/data-claims-reporting-service/templates/prometheus-rules.yaml
+++ b/.helm/data-claims-reporting-service/templates/prometheus-rules.yaml
@@ -82,7 +82,9 @@ spec:
             message: Job has failed to be created
             dashboard_url: {{ .Values.alerting.grafanaDashboard }}
           expr: |-
-            count(kube_job_created{namespace="{{ .Release.Namespace }}"} and (time() - kube_job_created < 24 * 3600))
+            (count(kube_job_created{namespace="{{ .Release.Namespace }}"} and (time() - kube_job_created < 24 * 3600)) or vector(0)) == 0
+          # "or vector(0)" is basically saying there is a min 0. so this returns either the amount of jobs created or 0,
+          # it can't return Null, which is what it would default to if no jobs are created.
           for: 1m
           labels:
             severity: {{ .Values.alerting.severity }}


### PR DESCRIPTION
## What

[LPF-1444](https://dsdmoj.atlassian.net/browse/LPF-1444)

**Failed Job alert** - add in a `max by` filter so that one job can only alert once. We had it alerting twice as for whatever reason Prometheus received one entry with and one without a reason field

**No Created Job** - I forgot the comparison...oops. But also I hadn't appreciated the null handling involved. If no jobs are created than `count`ing the jobs created returned no results. Which is more akin to null than zero. As such, I've used `vector(0)` to force a minimum value. It will return either number of jobs created or zero, whichever is larger.

## Evidence
<img width="1214" height="596" alt="image" src="https://github.com/user-attachments/assets/fa47fab5-d189-42c4-a63d-b2de50fe9a7a" />

## Checklist

Before you ask people to review this PR:

- [x] Title follows the format `{type}({TICKET-NUMBER}): {brief description}`.   Example: `feat(ABC-123): add caching layer`
    - Type must be one of:
        - feat
        - fix
        - docs
        - chore
        - refactor
        - test
        - ci
        - build
        - perf
- [x] Bump Helm chart version (if you have changed the Helm templates)
- [x] Tests should be passing: `./gradlew test` & `./gradlew integrationTest`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.


[LPF-1444]: https://dsdmoj.atlassian.net/browse/LPF-1444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ