### PR TITLE
chore: cleanup unneeded dependencies now Spring Boot update

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -2,25 +2,4 @@
 version: v1.25.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
-  SNYK-JAVA-TOOLSJACKSONCORE-15907550:
-    - '*':
-        reason: Issue with Json parser we don't use, so wait for Spring to catch up with fix
-        expires: 2026-05-08T00:00:00.000Z
-        created: 2026-04-08T00:00:00.000Z
-  SNYK-JAVA-ORGAPACHETOMCATEMBED-15989820:
-    - '*':
-        reason: >-
-          Tomcat version managed by LAA Spring Boot plugin. 
-          Not using CLIENT_CERT authentication where vulnerability applies.
-          Will be fixed when plugin updates dependency.
-        expires: 2026-06-13T00:00:00.000Z
-        created: 2026-04-13T00:00:00.000Z
-  SNYK-JAVA-ORGAPACHETOMCATEMBED-16643259:
-    - '*':
-        reason: >-
-          Tomcat version managed by LAA Spring Boot plugin.
-          Allocation of Resources vulnerability not applicable to our use case.
-          Will be fixed when plugin updates dependency.
-        expires: 2026-06-30T00:00:00.000Z
-        created: 2026-05-13T00:00:00.000Z
 patch: {}

--- a/build.gradle
+++ b/build.gradle
@@ -57,16 +57,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'
 
-    // Resolve snyk scan
-    implementation(platform("io.netty:netty-codec-compression:4.2.15.Final"))
-    implementation(platform("io.netty:netty-codec-http2:4.2.15.Final"))
-    implementation(platform("io.netty:netty-codec-http:4.2.15.Final"))
-    implementation(platform("io.netty:netty-transport-classes-epoll:4.2.15.Final"))
-    implementation(platform("io.netty:netty-codec-http:4.2.15.Final"))
-
-    // Resolve snyk scan
-    implementation 'org.apache.tomcat.embed:tomcat-embed-core:11.0.22'
-
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.3'
 
     implementation 'org.mapstruct:mapstruct:1.6.3'
@@ -83,10 +73,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-micrometer-tracing-brave'
     implementation 'io.micrometer:micrometer-tracing-bridge-brave'
 
-    implementation 'tools.jackson.dataformat:jackson-dataformat-csv:3.1.4'
+    implementation 'tools.jackson.dataformat:jackson-dataformat-csv'
 
     runtimeOnly 'org.springframework.boot:spring-boot-starter-flyway'
-    runtimeOnly 'org.postgresql:postgresql:42.7.11'
+    runtimeOnly 'org.postgresql:postgresql'
     runtimeOnly "org.flywaydb:flyway-database-postgresql"
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'


### PR DESCRIPTION

## What

[chore](https://dsdmoj.atlassian.net/browse/LPF-XXX)

1. Remove dependencies that were only added explicility to resolve CVEs while we awaited Spring Boot's update.
2. Remove versions for Jackson and Postgres - Spring Boot manages these and are at the same versions as we specified
3. Remove unused Snyk ignores, we no longer need to ignore these.

## Evidence
Only Snyk issue when locally run is a Medium, which is fine and below our threshold - checkstyle is inherited and managed from the LAA Spring Boot Common Plugin.
<img width="2043" height="330" alt="image" src="https://github.com/user-attachments/assets/7344136d-168f-4658-850a-e52a38c8a2d0" />


## Checklist

Before you ask people to review this PR:

- [x] Title follows the format `{type}({TICKET-NUMBER}): {brief description}`.   Example: `feat(ABC-123): add caching layer`
    - Type must be one of:
        - feat
        - fix
        - docs
        - chore
        - refactor
        - test
        - ci
        - build
        - perf
- [ ] Bump Helm chart version (if you have changed the Helm templates)
- [x] Tests should be passing: `./gradlew test` & `./gradlew integrationTest`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
