### PR TITLE
feat(LPF-1453): add database metrics for Postgres at end of job

### DIFF
--- a/src/main/java/uk/gov/justice/laa/dstew/claimsreports/config/MetricsHandler.java
+++ b/src/main/java/uk/gov/justice/laa/dstew/claimsreports/config/MetricsHandler.java
@@ -3,14 +3,16 @@ package uk.gov.justice.laa.dstew.claimsreports.config;
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 import io.prometheus.metrics.exporter.pushgateway.PushGateway;
 import jakarta.annotation.PreDestroy;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import uk.gov.justice.laa.dstew.claimsreports.config.PrometheusConfiguration.CustomReportGauges.CustomReportMetric;
+import uk.gov.justice.laa.dstew.claimsreports.config.PrometheusConfiguration.CustomMetricId;
 
 /**
  * Pushes prometheus metrics from ephemeral job to pushgateway.
  */
 @Component
+@Slf4j
 public class MetricsHandler {
 
   @Value("${GATEWAY_ADDRESS}")
@@ -19,8 +21,10 @@ public class MetricsHandler {
   private final PrometheusMeterRegistry reportPrometheusMeterRegistry;
   private final PrometheusMeterRegistry jobPrometheusMeterRegistry;
   private final PrometheusMeterRegistry replicationHealthPrometheusMeterRegistry;
+  private final PrometheusMeterRegistry databaseHealthPrometheusMeterRegistry;
   private final PrometheusConfiguration.CustomReportGauges customReportGauges;
   private final PrometheusConfiguration.ReplicationHealthGauge replicationHealthCheckGauge;
+  private final PrometheusConfiguration.DatabaseHealthGauge databaseHealthGauge;
 
   /**
    * Creates a Metrics Handler.
@@ -34,14 +38,18 @@ public class MetricsHandler {
   public MetricsHandler(PrometheusMeterRegistry reportPrometheusMeterRegistry,
                         PrometheusMeterRegistry jobPrometheusMeterRegistry,
                         PrometheusMeterRegistry replicationHealthPrometheusMeterRegistry,
+                        PrometheusMeterRegistry databaseHealthPrometheusMeterRegistry,
                         PrometheusConfiguration.CustomReportGauges customReportGauges,
-                        PrometheusConfiguration.ReplicationHealthGauge replicationHealthCheckGauge
+                        PrometheusConfiguration.ReplicationHealthGauge replicationHealthCheckGauge,
+                        PrometheusConfiguration.DatabaseHealthGauge databaseHealthGauge
   ) {
     this.reportPrometheusMeterRegistry = reportPrometheusMeterRegistry;
     this.jobPrometheusMeterRegistry = jobPrometheusMeterRegistry;
     this.replicationHealthPrometheusMeterRegistry = replicationHealthPrometheusMeterRegistry;
+    this.databaseHealthPrometheusMeterRegistry = databaseHealthPrometheusMeterRegistry;
     this.customReportGauges = customReportGauges;
     this.replicationHealthCheckGauge = replicationHealthCheckGauge;
+    this.databaseHealthGauge = databaseHealthGauge;
   }
 
   public void resetCustomMetrics() {
@@ -51,10 +59,10 @@ public class MetricsHandler {
   /**
    * Set a custom metrics value. This helps isolate metric setting from the actual code calling it.
    *
-   * @param metric metric to set from the {@link CustomReportMetric} enum
+   * @param metric metric to set from the {@link CustomMetricId} enum
    * @param value value to set metric to
    */
-  public void setCustomMetric(CustomReportMetric metric, long value) {
+  public void setCustomMetric(CustomMetricId metric, double value) {
     switch (metric) {
       case ROWS_WRITTEN -> customReportGauges.rowsWritten().set(value);
       case REPORT_TOTAL_TIME_MS -> customReportGauges.reportTotalTime().set(value);
@@ -65,7 +73,13 @@ public class MetricsHandler {
       case GENERATED_TIME_MS -> customReportGauges.generatedTimeMs().set(value);
       case ENCODING_CHECK_TIME_MS -> customReportGauges.encodingCheckTimeMs().set(value);
       case REPLICATION_HEALTH_CHECK_STATUS -> replicationHealthCheckGauge.replicationHealthCheck().set(value);
-      default -> throw new EnumConstantNotPresentException(CustomReportMetric.class, metric.name());
+      case DB_CONNECTIONS_TOTAL -> databaseHealthGauge.totalConnections().set(value);
+      case DB_CONNECTIONS_ACTIVE -> databaseHealthGauge.activeConnections().set(value);
+      case DB_CONNECTIONS_IDLE -> databaseHealthGauge.idleConnections().set(value);
+      case DB_CONNECTIONS_MAX_CONNECTIONS -> databaseHealthGauge.maxConnections().set(value);
+      case DB_CONNECTIONS_UTILISATION_ACTIVE -> databaseHealthGauge.activeUtilisation().set(value);
+      case DB_CONNECTIONS_UTILISATION_TOTAL -> databaseHealthGauge.totalUtilisation().set(value);
+      default -> throw new EnumConstantNotPresentException(CustomMetricId.class, metric.name());
     }
   }
 
@@ -80,7 +94,7 @@ public class MetricsHandler {
               .registry(reportPrometheusMeterRegistry.getPrometheusRegistry()).build()
               .push();
     } catch (Exception e) {
-      System.err.println("Failed to push metrics: " + e.getMessage());
+      log.error("Failed to push report metrics", e);
     }
   }
 
@@ -96,7 +110,7 @@ public class MetricsHandler {
               .registry(jobPrometheusMeterRegistry.getPrometheusRegistry()).build()
               .push();
     } catch (Exception e) {
-      System.err.println("Failed to push metrics: " + e.getMessage());
+      log.error("Failed to push end of job metrics", e);
     }
   }
 
@@ -112,7 +126,23 @@ public class MetricsHandler {
               .build()
               .push();
     } catch (Exception e) {
-      System.err.println("Failed to push metrics: " + e.getMessage());
+      log.error("Failed to push replication health metrics", e);
+    }
+  }
+
+  /**
+   * Push replication health metrics.
+   */
+  public void pushDatabaseHealthMetrics() {
+    try {
+      PushGateway.builder()
+          .address(gatewayAddress)
+          .job("databaseHealth")
+          .registry(databaseHealthPrometheusMeterRegistry.getPrometheusRegistry())
+          .build()
+          .push();
+    } catch (Exception e) {
+      log.error("Failed to push database metrics", e);
     }
   }
 }

--- a/src/main/java/uk/gov/justice/laa/dstew/claimsreports/config/PrometheusConfiguration.java
+++ b/src/main/java/uk/gov/justice/laa/dstew/claimsreports/config/PrometheusConfiguration.java
@@ -123,7 +123,7 @@ public class PrometheusConfiguration {
    * @return database health check gauge
    */
   @Bean
-  public DatabaseHealthGauge databaseHealthGauge(
+  public DatabaseHealthGauge createDatabaseHealthGauge(
       PrometheusMeterRegistry databaseHealthPrometheusMeterRegistry) {
     var totalConnections = Gauge.builder()
         .withoutExemplars()

--- a/src/main/java/uk/gov/justice/laa/dstew/claimsreports/config/PrometheusConfiguration.java
+++ b/src/main/java/uk/gov/justice/laa/dstew/claimsreports/config/PrometheusConfiguration.java
@@ -79,9 +79,97 @@ public class PrometheusConfiguration {
   }
 
   /**
+   * Identifier for a custom metric.
+   */
+  public enum CustomMetricId {
+    REPORT_SUCCESSFUL,
+    REPORT_TOTAL_TIME_MS,
+    DATA_REFRESH_TIME_MS,
+    GENERATED_TIME_MS,
+    ROWS_WRITTEN,
+    REPORT_FILE_SIZE,
+    UPLOAD_TIME_MS,
+    ENCODING_CHECK_TIME_MS,
+    REPLICATION_HEALTH_CHECK_STATUS,
+    DB_CONNECTIONS_TOTAL,
+    DB_CONNECTIONS_ACTIVE,
+    DB_CONNECTIONS_IDLE,
+    DB_CONNECTIONS_MAX_CONNECTIONS,
+    DB_CONNECTIONS_UTILISATION_ACTIVE,
+    DB_CONNECTIONS_UTILISATION_TOTAL
+  }
+
+  /**
    * This class defines the replication health metric we push to Prometheus.
    */
   public record ReplicationHealthGauge(Gauge replicationHealthCheck) {}
+
+  /**
+   * This registry is used to isolate replication health metric pushes at the end of the process instead of bundling
+   * with job registry.
+   *
+   * @return registry for (replication health)-level metrics
+   */
+  @Bean
+  public PrometheusMeterRegistry databaseHealthPrometheusMeterRegistry() {
+    return new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+  }
+
+  /**
+   * Create a gauge for the database health checks, registered on the database health registry.
+   * These are collected at the end of the process
+   *
+   * @param databaseHealthPrometheusMeterRegistry database health registry
+   * @return database health check gauge
+   */
+  @Bean
+  public DatabaseHealthGauge databaseHealthGauge(
+      PrometheusMeterRegistry databaseHealthPrometheusMeterRegistry) {
+    var totalConnections = Gauge.builder()
+        .withoutExemplars()
+        .name("database_connectons_total_open")
+        .help("Total open connections to the database at the end of the cronjob")
+        .register(databaseHealthPrometheusMeterRegistry.getPrometheusRegistry());
+
+    var activeConnections = Gauge.builder()
+        .withoutExemplars()
+        .name("database_connections_active")
+        .help("Active connections at the end of the cronjob")
+        .register(databaseHealthPrometheusMeterRegistry.getPrometheusRegistry());
+
+    var idleConnections = Gauge.builder()
+        .withoutExemplars()
+        .name("database_connections_idle")
+        .help("Idle connections at the end of the cronjob")
+        .register(databaseHealthPrometheusMeterRegistry.getPrometheusRegistry());
+
+    var maxConnections = Gauge.builder()
+        .withoutExemplars()
+        .name("database_connections_max")
+        .help("Max connections")
+        .register(databaseHealthPrometheusMeterRegistry.getPrometheusRegistry());
+
+    var activeUtilisation = Gauge.builder()
+        .withoutExemplars()
+        .name("database_connections_active_utilisation")
+        .help("Active utilisation rate (active/max)")
+        .register(databaseHealthPrometheusMeterRegistry.getPrometheusRegistry());
+
+    var totalUtilisation = Gauge.builder()
+        .withoutExemplars()
+        .name("database_connections_total_utilisation")
+        .help("Total utilisation rate (total/max)")
+        .register(databaseHealthPrometheusMeterRegistry.getPrometheusRegistry());
+
+    return new DatabaseHealthGauge(totalConnections, activeConnections, idleConnections, maxConnections,
+        activeUtilisation, totalUtilisation);
+  }
+
+  /**
+   * This class defines the replication health metric we push to Prometheus.
+   */
+  public record DatabaseHealthGauge(Gauge totalConnections, Gauge activeConnections, Gauge idleConnections,
+                                    Gauge maxConnections, Gauge activeUtilisation, Gauge totalUtilisation) {}
 
   /**
    * Create a set of custom gauges for measuring report stats.
@@ -154,21 +242,6 @@ public class PrometheusConfiguration {
     public static int REPORT_FAILED = -1;
     public static int REPORT_SUCCESSFUL = 1;
     public static int REPORT_SKIPPED = 0;
-
-    /**
-     * Identifier for a custom metric.
-     */
-    public enum CustomReportMetric {
-      REPORT_SUCCESSFUL,
-      REPORT_TOTAL_TIME_MS,
-      DATA_REFRESH_TIME_MS,
-      GENERATED_TIME_MS,
-      ROWS_WRITTEN,
-      REPORT_FILE_SIZE,
-      UPLOAD_TIME_MS,
-      ENCODING_CHECK_TIME_MS,
-      REPLICATION_HEALTH_CHECK_STATUS
-    }
 
     /**
      * Reset the metrics.

--- a/src/main/java/uk/gov/justice/laa/dstew/claimsreports/config/PrometheusConfiguration.java
+++ b/src/main/java/uk/gov/justice/laa/dstew/claimsreports/config/PrometheusConfiguration.java
@@ -127,7 +127,7 @@ public class PrometheusConfiguration {
       PrometheusMeterRegistry databaseHealthPrometheusMeterRegistry) {
     var totalConnections = Gauge.builder()
         .withoutExemplars()
-        .name("database_connectons_total_open")
+        .name("database_connections_total_open")
         .help("Total open connections to the database at the end of the cronjob")
         .register(databaseHealthPrometheusMeterRegistry.getPrometheusRegistry());
 

--- a/src/main/java/uk/gov/justice/laa/dstew/claimsreports/runner/ClaimsReportingServiceRunner.java
+++ b/src/main/java/uk/gov/justice/laa/dstew/claimsreports/runner/ClaimsReportingServiceRunner.java
@@ -1,6 +1,6 @@
 package uk.gov.justice.laa.dstew.claimsreports.runner;
 
-import static uk.gov.justice.laa.dstew.claimsreports.config.PrometheusConfiguration.CustomReportGauges.CustomReportMetric.REPLICATION_HEALTH_CHECK_STATUS;
+import static uk.gov.justice.laa.dstew.claimsreports.config.PrometheusConfiguration.CustomMetricId.REPLICATION_HEALTH_CHECK_STATUS;
 import static uk.gov.justice.laa.dstew.claimsreports.config.PrometheusConfiguration.CustomReportGauges.REPORT_FAILED;
 
 import java.util.List;
@@ -11,9 +11,10 @@ import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.stereotype.Component;
 import uk.gov.justice.laa.dstew.claimsreports.config.MetricsHandler;
-import uk.gov.justice.laa.dstew.claimsreports.config.PrometheusConfiguration.CustomReportGauges.CustomReportMetric;
+import uk.gov.justice.laa.dstew.claimsreports.config.PrometheusConfiguration.CustomMetricId;
 import uk.gov.justice.laa.dstew.claimsreports.dto.ReplicationHealthReport;
 import uk.gov.justice.laa.dstew.claimsreports.service.AbstractReportService;
+import uk.gov.justice.laa.dstew.claimsreports.service.DatabaseStatisticService;
 import uk.gov.justice.laa.dstew.claimsreports.service.ReplicationHealthCheckService;
 
 
@@ -51,6 +52,7 @@ public class ClaimsReportingServiceRunner implements ApplicationRunner {
   private final List<AbstractReportService> reportServices;
 
   private final MetricsHandler metricsHandler;
+  private final DatabaseStatisticService databaseStatisticService;
 
   @Override
   public void run(ApplicationArguments args) {
@@ -60,6 +62,10 @@ public class ClaimsReportingServiceRunner implements ApplicationRunner {
       log.error("Replication health check failed, reports not generated.");
       markAllReportsFailedDueToReplication();
     }
+
+    databaseStatisticService.setDatabaseMetrics();
+    metricsHandler.pushDatabaseHealthMetrics();
+
   }
 
   /**
@@ -132,10 +138,10 @@ public class ClaimsReportingServiceRunner implements ApplicationRunner {
       } catch (Exception e) {
         log.error("Report generation failed for {}: {}",
                 service.getClass().getSimpleName(), e.getMessage(), e);
-        metricsHandler.setCustomMetric(CustomReportMetric.REPORT_SUCCESSFUL, REPORT_FAILED);
+        metricsHandler.setCustomMetric(CustomMetricId.REPORT_SUCCESSFUL, REPORT_FAILED);
       } finally {
         var reportDuration = System.currentTimeMillis() - startTime;
-        metricsHandler.setCustomMetric(CustomReportMetric.REPORT_TOTAL_TIME_MS, reportDuration);
+        metricsHandler.setCustomMetric(CustomMetricId.REPORT_TOTAL_TIME_MS, reportDuration);
         log.info("Report generation for report {} took {} ms ({} s)", service.getReportName(), reportDuration, reportDuration / 1000);
         metricsHandler.pushReportMetrics(service.getReportName());
       }
@@ -147,7 +153,7 @@ public class ClaimsReportingServiceRunner implements ApplicationRunner {
     for (AbstractReportService service : reportServices) {
       String reportName = service.getReportName();
       metricsHandler.resetCustomMetrics();
-      metricsHandler.setCustomMetric(CustomReportMetric.REPORT_SUCCESSFUL, REPORT_FAILED);
+      metricsHandler.setCustomMetric(CustomMetricId.REPORT_SUCCESSFUL, REPORT_FAILED);
       metricsHandler.pushReportMetrics(reportName);
     }
   }

--- a/src/main/java/uk/gov/justice/laa/dstew/claimsreports/service/AbstractReportService.java
+++ b/src/main/java/uk/gov/justice/laa/dstew/claimsreports/service/AbstractReportService.java
@@ -14,7 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.justice.laa.dstew.claimsreports.config.MetricsHandler;
-import uk.gov.justice.laa.dstew.claimsreports.config.PrometheusConfiguration.CustomReportGauges.CustomReportMetric;
+import uk.gov.justice.laa.dstew.claimsreports.config.PrometheusConfiguration.CustomMetricId;
 import uk.gov.justice.laa.dstew.claimsreports.exception.CsvCreationException;
 import uk.gov.justice.laa.dstew.claimsreports.service.s3.S3ClientWrapper;
 
@@ -57,7 +57,7 @@ public abstract class AbstractReportService {
     long endTime = System.currentTimeMillis();
     long durationMilliseconds = endTime - startTime;
     log.info("Refresh complete for {} in {} ms", getReportName(), durationMilliseconds);
-    metricsHandler.setCustomMetric(CustomReportMetric.DATA_REFRESH_TIME_MS, durationMilliseconds);
+    metricsHandler.setCustomMetric(CustomMetricId.DATA_REFRESH_TIME_MS, durationMilliseconds);
   }
 
   /**
@@ -121,7 +121,7 @@ public abstract class AbstractReportService {
   public void generateReport() {
     if (!runToday()) {
       log.info("Report {} is not scheduled to run today", getReportName());
-      metricsHandler.setCustomMetric(CustomReportMetric.REPORT_SUCCESSFUL, REPORT_SKIPPED);
+      metricsHandler.setCustomMetric(CustomMetricId.REPORT_SUCCESSFUL, REPORT_SKIPPED);
       return;
     }
 
@@ -142,9 +142,9 @@ public abstract class AbstractReportService {
       long endTime = System.currentTimeMillis();
       long durationMilliseconds = endTime - startTime;
       log.info("Created {} file with filename {} in {} ms", getReportName(), getFullReportFileName(), durationMilliseconds);
-      metricsHandler.setCustomMetric(CustomReportMetric.GENERATED_TIME_MS, durationMilliseconds);
+      metricsHandler.setCustomMetric(CustomMetricId.GENERATED_TIME_MS, durationMilliseconds);
       s3ClientWrapper.uploadFile(tempFile, generateS3FileKey());
-      metricsHandler.setCustomMetric(CustomReportMetric.REPORT_SUCCESSFUL, REPORT_SUCCESSFUL);
+      metricsHandler.setCustomMetric(CustomMetricId.REPORT_SUCCESSFUL, REPORT_SUCCESSFUL);
 
     } catch (Exception e) {
       log.error("Failed to generate {}: {}", getReportName(), e.getMessage());

--- a/src/main/java/uk/gov/justice/laa/dstew/claimsreports/service/CsvCreationService.java
+++ b/src/main/java/uk/gov/justice/laa/dstew/claimsreports/service/CsvCreationService.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Service;
 import tools.jackson.dataformat.csv.CsvMapper;
 import uk.gov.justice.laa.dstew.claimsreports.config.AppConfig;
 import uk.gov.justice.laa.dstew.claimsreports.config.MetricsHandler;
-import uk.gov.justice.laa.dstew.claimsreports.config.PrometheusConfiguration.CustomReportGauges.CustomReportMetric;
+import uk.gov.justice.laa.dstew.claimsreports.config.PrometheusConfiguration.CustomMetricId;
 import uk.gov.justice.laa.dstew.claimsreports.exception.CsvCreationException;
 
 /**
@@ -61,7 +61,7 @@ public class CsvCreationService {
       log.info("CSV creation completed for {}", reportName);
       var rowsWritten = handler.getRowCount();
       log.info("Rows written for {}: " + rowsWritten, reportName);
-      metricsHandler.setCustomMetric(CustomReportMetric.ROWS_WRITTEN, rowsWritten);
+      metricsHandler.setCustomMetric(CustomMetricId.ROWS_WRITTEN, rowsWritten);
 
     } catch (IOException ex) {
       throw new CsvCreationException("Failure to write to file for " + reportName, ex);

--- a/src/main/java/uk/gov/justice/laa/dstew/claimsreports/service/DatabaseStatisticService.java
+++ b/src/main/java/uk/gov/justice/laa/dstew/claimsreports/service/DatabaseStatisticService.java
@@ -1,0 +1,47 @@
+package uk.gov.justice.laa.dstew.claimsreports.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+import uk.gov.justice.laa.dstew.claimsreports.config.MetricsHandler;
+import uk.gov.justice.laa.dstew.claimsreports.config.PrometheusConfiguration.CustomMetricId;
+
+
+/**
+ * Calculate and set metrics pertaining to database performance.
+ */
+@Service
+@RequiredArgsConstructor
+public class DatabaseStatisticService {
+
+  protected static final String QUERY_TOTAL_CONNECTIONS = "SELECT count(*) FROM pg_stat_activity";
+  public static final String QUERY_ACTIVE_CONNECTIONS = "SELECT count(*) FROM pg_stat_activity WHERE state = 'active'";
+  public static final String QUERY_IDLE_CONNECTIONS = "SELECT count(*) FROM pg_stat_activity WHERE state = 'idle'";
+  public static final String QUERY_MAX_CONNECTIONS = "SHOW max_connections;";
+  private final JdbcTemplate jdbcTemplate;
+  private final MetricsHandler metricsHandler;
+
+  /**
+   * Get database statistics and set them as metrics.
+   */
+  public void setDatabaseMetrics() {
+    var totalConnections = jdbcTemplate.queryForObject(QUERY_TOTAL_CONNECTIONS, Double.class);
+    metricsHandler.setCustomMetric(CustomMetricId.DB_CONNECTIONS_TOTAL, totalConnections != null ? totalConnections : 0);
+
+    var activeConnections = jdbcTemplate.queryForObject(QUERY_ACTIVE_CONNECTIONS, Double.class);
+    metricsHandler.setCustomMetric(CustomMetricId.DB_CONNECTIONS_ACTIVE, activeConnections != null ? activeConnections : 0);
+
+    var idleConnections = jdbcTemplate.queryForObject(QUERY_IDLE_CONNECTIONS, Double.class);
+    metricsHandler.setCustomMetric(CustomMetricId.DB_CONNECTIONS_IDLE, idleConnections != null ? idleConnections : 0);
+
+    var maxConnections = jdbcTemplate.queryForObject(QUERY_MAX_CONNECTIONS, Double.class);
+    metricsHandler.setCustomMetric(CustomMetricId.DB_CONNECTIONS_MAX_CONNECTIONS, maxConnections != null ? maxConnections : 0);
+
+    var activeUtilisation = (maxConnections == null || activeConnections == null || maxConnections == 0) ? 0 : activeConnections / maxConnections;
+    metricsHandler.setCustomMetric(CustomMetricId.DB_CONNECTIONS_UTILISATION_ACTIVE, activeUtilisation);
+
+    var totalUtilisation = (maxConnections == null || totalConnections == null || maxConnections == 0) ? 0 : totalConnections / maxConnections;
+    metricsHandler.setCustomMetric(CustomMetricId.DB_CONNECTIONS_UTILISATION_TOTAL, totalUtilisation);
+
+  }
+}

--- a/src/main/java/uk/gov/justice/laa/dstew/claimsreports/service/s3/S3ClientWrapper.java
+++ b/src/main/java/uk/gov/justice/laa/dstew/claimsreports/service/s3/S3ClientWrapper.java
@@ -6,7 +6,7 @@ import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import uk.gov.justice.laa.dstew.claimsreports.config.MetricsHandler;
-import uk.gov.justice.laa.dstew.claimsreports.config.PrometheusConfiguration.CustomReportGauges.CustomReportMetric;
+import uk.gov.justice.laa.dstew.claimsreports.config.PrometheusConfiguration.CustomMetricId;
 import uk.gov.justice.laa.dstew.claimsreports.exception.CsvUploadException;
 import uk.gov.justice.laa.dstew.claimsreports.service.CsvFileValidator;
 
@@ -84,7 +84,7 @@ public class S3ClientWrapper {
     }
     long encodingDuration = System.currentTimeMillis() - encodingCheckStart;
     log.info("File {} is valid UTF-8. Check took {} ms", fileName, encodingDuration);
-    metricsHandler.setCustomMetric(CustomReportMetric.ENCODING_CHECK_TIME_MS, encodingDuration);
+    metricsHandler.setCustomMetric(CustomMetricId.ENCODING_CHECK_TIME_MS, encodingDuration);
 
     var putRequest = PutObjectRequest.builder()
         .bucket(s3Bucket)
@@ -102,8 +102,8 @@ public class S3ClientWrapper {
 
     // Using MiB as that is what system storage use and isn't user-facing.
     var fileSizeMib = fileToUpload.length() / 1024 / 1024;
-    metricsHandler.setCustomMetric(CustomReportMetric.UPLOAD_TIME_MS, durationMilliseconds);
-    metricsHandler.setCustomMetric(CustomReportMetric.REPORT_FILE_SIZE, fileSizeMib);
+    metricsHandler.setCustomMetric(CustomMetricId.UPLOAD_TIME_MS, durationMilliseconds);
+    metricsHandler.setCustomMetric(CustomMetricId.REPORT_FILE_SIZE, fileSizeMib);
     log.info("Uploaded {} to S3 bucket {} with filename {} and size {} MiB in {} ms",
         fileToUpload.getPath(), s3Bucket, desiredFileKey, fileSizeMib, durationMilliseconds);
   }

--- a/src/test/java/uk/gov/justice/laa/dstew/claimsreports/config/MetricsHandlerTest.java
+++ b/src/test/java/uk/gov/justice/laa/dstew/claimsreports/config/MetricsHandlerTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.justice.laa.dstew.claimsreports.config.PrometheusConfiguration.CustomReportGauges.CustomReportMetric;
+import uk.gov.justice.laa.dstew.claimsreports.config.PrometheusConfiguration.CustomMetricId;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -38,7 +38,7 @@ class MetricsHandlerTest {
   void shouldSetMetrics() {
     var mockGauge = mock(Gauge.class);
     when(customReportGauges.reportFileSize()).thenReturn(mockGauge);
-    metricsHandler.setCustomMetric(CustomReportMetric.REPORT_FILE_SIZE, 1234);
+    metricsHandler.setCustomMetric(CustomMetricId.REPORT_FILE_SIZE, 1234);
     verify(mockGauge).set(1234);
   }
 

--- a/src/test/java/uk/gov/justice/laa/dstew/claimsreports/config/PrometheusConfigurationTest.java
+++ b/src/test/java/uk/gov/justice/laa/dstew/claimsreports/config/PrometheusConfigurationTest.java
@@ -64,4 +64,17 @@ class PrometheusConfigurationTest {
     assertEquals(0, customMetrics.uploadTimeMs().get());
   }
 
+  @Test
+  void shouldCreateDbHealthMetrics() {
+    prometheusConfiguration = new PrometheusConfiguration();
+    when(prometheusMeterRegistry.getPrometheusRegistry()).thenReturn(mock(PrometheusRegistry.class));
+    var customMetrics = prometheusConfiguration.createDatabaseHealthGauge(prometheusMeterRegistry);
+
+    assertNotNull(customMetrics.idleConnections());
+    assertNotNull(customMetrics.activeConnections());
+    assertNotNull(customMetrics.totalConnections());
+    assertNotNull(customMetrics.maxConnections());
+    assertNotNull(customMetrics.totalUtilisation());
+    assertNotNull(customMetrics.activeUtilisation());
+  }
 }

--- a/src/test/java/uk/gov/justice/laa/dstew/claimsreports/runner/ClaimsReportingServiceRunnerTest.java
+++ b/src/test/java/uk/gov/justice/laa/dstew/claimsreports/runner/ClaimsReportingServiceRunnerTest.java
@@ -8,7 +8,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.justice.laa.dstew.claimsreports.config.PrometheusConfiguration.CustomReportGauges.REPORT_FAILED;
-import static uk.gov.justice.laa.dstew.claimsreports.config.PrometheusConfiguration.CustomReportGauges.CustomReportMetric.REPLICATION_HEALTH_CHECK_STATUS;
+import static uk.gov.justice.laa.dstew.claimsreports.config.PrometheusConfiguration.CustomMetricId.REPLICATION_HEALTH_CHECK_STATUS;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -21,9 +21,10 @@ import org.springframework.boot.ApplicationArguments;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import uk.gov.justice.laa.dstew.claimsreports.config.MetricsHandler;
-import uk.gov.justice.laa.dstew.claimsreports.config.PrometheusConfiguration.CustomReportGauges.CustomReportMetric;
+import uk.gov.justice.laa.dstew.claimsreports.config.PrometheusConfiguration.CustomMetricId;
 import uk.gov.justice.laa.dstew.claimsreports.dto.ReplicationHealthReport;
 import uk.gov.justice.laa.dstew.claimsreports.service.AbstractReportService;
+import uk.gov.justice.laa.dstew.claimsreports.service.DatabaseStatisticService;
 import uk.gov.justice.laa.dstew.claimsreports.service.ReplicationHealthCheckService;
 
 class ClaimsReportingServiceRunnerTest {
@@ -43,6 +44,9 @@ class ClaimsReportingServiceRunnerTest {
   @Mock
   private MetricsHandler metricsHandler;
 
+  @Mock
+  private DatabaseStatisticService databaseStatisticService;
+
   private ClaimsReportingServiceRunner runner;
 
   @BeforeEach
@@ -53,7 +57,8 @@ class ClaimsReportingServiceRunnerTest {
     runner = new ClaimsReportingServiceRunner(
             replicationHealthCheckService,
             List.of(reportService1, reportService2),
-            metricsHandler
+            metricsHandler,
+            databaseStatisticService
     );
 
     // Default behaviour: replication is healthy
@@ -104,7 +109,7 @@ class ClaimsReportingServiceRunnerTest {
   void shouldHandleEmptyServiceList() {
     // Create runner with empty list of report services
     ClaimsReportingServiceRunner emptyRunner =
-            new ClaimsReportingServiceRunner(replicationHealthCheckService, List.of(), metricsHandler);
+            new ClaimsReportingServiceRunner(replicationHealthCheckService, List.of(), metricsHandler, databaseStatisticService);
 
     // Should not throw any exceptions
     assertThatCode(() -> emptyRunner.run(applicationArguments))
@@ -128,7 +133,7 @@ class ClaimsReportingServiceRunnerTest {
     verify(reportService2).generateReport();
 
     // Failure metric should be recorded
-    verify(metricsHandler).setCustomMetric(CustomReportMetric.REPORT_SUCCESSFUL, REPORT_FAILED);
+    verify(metricsHandler).setCustomMetric(CustomMetricId.REPORT_SUCCESSFUL, REPORT_FAILED);
   }
 
   @Test
@@ -174,7 +179,7 @@ class ClaimsReportingServiceRunnerTest {
     // Each report should be marked as failed
     verify(metricsHandler, times(2)).resetCustomMetrics();
     verify(metricsHandler, times(2))
-            .setCustomMetric(eq(CustomReportMetric.REPORT_SUCCESSFUL), eq((long) REPORT_FAILED));
+            .setCustomMetric(eq(CustomMetricId.REPORT_SUCCESSFUL), eq((double) REPORT_FAILED));
 
     // Metrics pushed per report
     verify(metricsHandler).pushReportMetrics("report1");
@@ -207,7 +212,8 @@ class ClaimsReportingServiceRunnerTest {
     runner = new ClaimsReportingServiceRunner(
             replicationHealthCheckService,
             List.of(reportService1, reportService2),
-            metricsHandler
+            metricsHandler,
+            databaseStatisticService
     );
 
     // enable ignoreRowCountMismatch feature flag
@@ -241,7 +247,8 @@ class ClaimsReportingServiceRunnerTest {
     runner = new ClaimsReportingServiceRunner(
             replicationHealthCheckService,
             List.of(reportService1, reportService2),
-            metricsHandler
+            metricsHandler,
+            databaseStatisticService
     );
 
     // enable ignoreRowCountMismatch
@@ -255,7 +262,7 @@ class ClaimsReportingServiceRunnerTest {
 
     // all reports should be marked as failed
     verify(metricsHandler, times(2))
-            .setCustomMetric(eq(CustomReportMetric.REPORT_SUCCESSFUL), eq((long) REPORT_FAILED));
+            .setCustomMetric(eq(CustomMetricId.REPORT_SUCCESSFUL), eq((double) REPORT_FAILED));
 
     verify(metricsHandler).pushReportMetrics("report1");
     verify(metricsHandler).pushReportMetrics("report2");
@@ -265,5 +272,13 @@ class ClaimsReportingServiceRunnerTest {
     verify(reportService1, never()).generateReport();
     verify(reportService2, never()).refreshDataSource();
     verify(reportService2, never()).generateReport();
+  }
+
+  @Test
+  void shouldPublishDbHealthStats() {
+    runner.run(applicationArguments);
+
+    verify(databaseStatisticService).setDatabaseMetrics();
+    verify(metricsHandler).pushDatabaseHealthMetrics();
   }
 }

--- a/src/test/java/uk/gov/justice/laa/dstew/claimsreports/service/DatabaseStatisticServiceTest.java
+++ b/src/test/java/uk/gov/justice/laa/dstew/claimsreports/service/DatabaseStatisticServiceTest.java
@@ -1,0 +1,157 @@
+package uk.gov.justice.laa.dstew.claimsreports.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+import uk.gov.justice.laa.dstew.claimsreports.config.MetricsHandler;
+import uk.gov.justice.laa.dstew.claimsreports.config.PrometheusConfiguration.CustomMetricId;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.justice.laa.dstew.claimsreports.service.DatabaseStatisticService.QUERY_ACTIVE_CONNECTIONS;
+import static uk.gov.justice.laa.dstew.claimsreports.service.DatabaseStatisticService.QUERY_IDLE_CONNECTIONS;
+import static uk.gov.justice.laa.dstew.claimsreports.service.DatabaseStatisticService.QUERY_MAX_CONNECTIONS;
+import static uk.gov.justice.laa.dstew.claimsreports.service.DatabaseStatisticService.QUERY_TOTAL_CONNECTIONS;
+
+@ExtendWith(MockitoExtension.class)
+class DatabaseStatisticServiceTest {
+
+  @Mock
+  private JdbcTemplate jdbcTemplate;
+
+  @Mock
+  private MetricsHandler metricsHandler;
+
+  @InjectMocks
+  private DatabaseStatisticService databaseStatisticService;
+
+  @BeforeEach
+  void beforeEach() {
+    reset(jdbcTemplate, metricsHandler);
+    when(jdbcTemplate.queryForObject(anyString(), eq(Double.class))).thenReturn(null);
+  }
+
+  @Test
+  void should_set_totalConnections_when_not_null() {
+    when(jdbcTemplate.queryForObject(QUERY_TOTAL_CONNECTIONS, Double.class)).thenReturn(12.0);
+    databaseStatisticService.setDatabaseMetrics();
+    verify(metricsHandler).setCustomMetric(CustomMetricId.DB_CONNECTIONS_TOTAL, 12);
+  }
+
+  @Test
+  void should_set_idleConnections_when_not_null() {
+    when(jdbcTemplate.queryForObject(QUERY_IDLE_CONNECTIONS, Double.class)).thenReturn(13.0);
+    databaseStatisticService.setDatabaseMetrics();
+    verify(metricsHandler).setCustomMetric(CustomMetricId.DB_CONNECTIONS_IDLE, 13);
+  }
+
+  @Test
+  void should_set_activeConnections_when_not_null() {
+    when(jdbcTemplate.queryForObject(QUERY_ACTIVE_CONNECTIONS, Double.class)).thenReturn(14.0);
+    databaseStatisticService.setDatabaseMetrics();
+    verify(metricsHandler).setCustomMetric(CustomMetricId.DB_CONNECTIONS_ACTIVE, 14);
+  }
+
+  @Test
+  void should_set_maxConnections_when_not_null() {
+    when(jdbcTemplate.queryForObject(QUERY_MAX_CONNECTIONS, Double.class)).thenReturn(15.0);
+    databaseStatisticService.setDatabaseMetrics();
+    verify(metricsHandler).setCustomMetric(CustomMetricId.DB_CONNECTIONS_MAX_CONNECTIONS, 15);
+  }
+
+  @Test
+  void should_set_activeUtilisation_when_not_null() {
+    when(jdbcTemplate.queryForObject(QUERY_ACTIVE_CONNECTIONS, Double.class)).thenReturn(1.0);
+    when(jdbcTemplate.queryForObject(QUERY_MAX_CONNECTIONS, Double.class)).thenReturn(100.0);
+    databaseStatisticService.setDatabaseMetrics();
+    verify(metricsHandler).setCustomMetric(CustomMetricId.DB_CONNECTIONS_UTILISATION_ACTIVE, 0.01);
+  }
+
+  @Test
+  void should_set_totalUtilisation_when_not_null() {
+    when(jdbcTemplate.queryForObject(QUERY_TOTAL_CONNECTIONS, Double.class)).thenReturn(5.0);
+    when(jdbcTemplate.queryForObject(QUERY_MAX_CONNECTIONS, Double.class)).thenReturn(100.0);
+    databaseStatisticService.setDatabaseMetrics();
+    verify(metricsHandler).setCustomMetric(CustomMetricId.DB_CONNECTIONS_UTILISATION_TOTAL, 0.05);
+  }
+
+  @Test
+  void should_zero_totalConnections_when_null() {
+    databaseStatisticService.setDatabaseMetrics();
+    verify(metricsHandler).setCustomMetric(CustomMetricId.DB_CONNECTIONS_TOTAL, 0);
+  }
+
+  @Test
+  void should_zero_idleConnections_when_null() {
+    databaseStatisticService.setDatabaseMetrics();
+    verify(metricsHandler).setCustomMetric(CustomMetricId.DB_CONNECTIONS_IDLE, 0);
+  }
+
+  @Test
+  void should_zero_activeConnections_when_null() {
+    databaseStatisticService.setDatabaseMetrics();
+    verify(metricsHandler).setCustomMetric(CustomMetricId.DB_CONNECTIONS_ACTIVE, 0);
+  }
+
+  @Test
+  void should_zero_maxConnections_when_null() {
+    databaseStatisticService.setDatabaseMetrics();
+    verify(metricsHandler).setCustomMetric(CustomMetricId.DB_CONNECTIONS_MAX_CONNECTIONS, 0);
+  }
+
+  @Test
+  void should_zero_activeUtilisation_when_activeConnections_null() {
+    when(jdbcTemplate.queryForObject(QUERY_ACTIVE_CONNECTIONS, Double.class)).thenReturn(null);
+    when(jdbcTemplate.queryForObject(QUERY_MAX_CONNECTIONS, Double.class)).thenReturn(100.0);
+    databaseStatisticService.setDatabaseMetrics();
+    verify(metricsHandler).setCustomMetric(CustomMetricId.DB_CONNECTIONS_UTILISATION_ACTIVE, 0);
+  }
+
+  @Test
+  void should_zero_activeUtilisation_when_maxConnections_null() {
+    when(jdbcTemplate.queryForObject(QUERY_ACTIVE_CONNECTIONS, Double.class)).thenReturn(1.0);
+    when(jdbcTemplate.queryForObject(QUERY_MAX_CONNECTIONS, Double.class)).thenReturn(null);
+    databaseStatisticService.setDatabaseMetrics();
+    verify(metricsHandler).setCustomMetric(CustomMetricId.DB_CONNECTIONS_UTILISATION_ACTIVE, 0);
+  }
+
+  @Test
+  void should_zero_activeUtilisation_when_maxConnections_zero() {
+    when(jdbcTemplate.queryForObject(QUERY_ACTIVE_CONNECTIONS, Double.class)).thenReturn(1.0);
+    when(jdbcTemplate.queryForObject(QUERY_MAX_CONNECTIONS, Double.class)).thenReturn(0.0);
+    databaseStatisticService.setDatabaseMetrics();
+    verify(metricsHandler).setCustomMetric(CustomMetricId.DB_CONNECTIONS_UTILISATION_ACTIVE, 0);
+  }
+
+  @Test
+  void should_zero_totalUtilisation_when_totalConnections_null() {
+    when(jdbcTemplate.queryForObject(QUERY_TOTAL_CONNECTIONS, Double.class)).thenReturn(null);
+    when(jdbcTemplate.queryForObject(QUERY_MAX_CONNECTIONS, Double.class)).thenReturn(100.0);
+    databaseStatisticService.setDatabaseMetrics();
+    verify(metricsHandler).setCustomMetric(CustomMetricId.DB_CONNECTIONS_UTILISATION_TOTAL, 0);
+  }
+
+  @Test
+  void should_zero_totalUtilisation_when_maxConnections_null() {
+    when(jdbcTemplate.queryForObject(QUERY_TOTAL_CONNECTIONS, Double.class)).thenReturn(1.0);
+    when(jdbcTemplate.queryForObject(QUERY_MAX_CONNECTIONS, Double.class)).thenReturn(null);
+    databaseStatisticService.setDatabaseMetrics();
+    verify(metricsHandler).setCustomMetric(CustomMetricId.DB_CONNECTIONS_UTILISATION_TOTAL, 0);
+  }
+
+  @Test
+  void should_zero_totalUtilisation_when_maxConnections_zero() {
+    when(jdbcTemplate.queryForObject(QUERY_TOTAL_CONNECTIONS, Double.class)).thenReturn(1.0);
+    when(jdbcTemplate.queryForObject(QUERY_MAX_CONNECTIONS, Double.class)).thenReturn(0.0);
+    databaseStatisticService.setDatabaseMetrics();
+    verify(metricsHandler).setCustomMetric(CustomMetricId.DB_CONNECTIONS_UTILISATION_TOTAL, 0);
+  }
+
+}

--- a/src/test/java/uk/gov/justice/laa/dstew/claimsreports/service/s3/S3ClientWrapperTest.java
+++ b/src/test/java/uk/gov/justice/laa/dstew/claimsreports/service/s3/S3ClientWrapperTest.java
@@ -17,14 +17,14 @@ import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 import uk.gov.justice.laa.dstew.claimsreports.config.MetricsHandler;
-import uk.gov.justice.laa.dstew.claimsreports.config.PrometheusConfiguration.CustomReportGauges.CustomReportMetric;
+import uk.gov.justice.laa.dstew.claimsreports.config.PrometheusConfiguration.CustomMetricId;
 import uk.gov.justice.laa.dstew.claimsreports.exception.CsvUploadException;
 import uk.gov.justice.laa.dstew.claimsreports.service.CsvFileValidator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
@@ -79,8 +79,8 @@ class S3ClientWrapperTest {
     assertEquals(Files.readString(Path.of(testFilePath)), getRequestBodyContents(requestBody));
 
     // Check metrics logged
-    verify(metricsHandler).setCustomMetric(eq(CustomReportMetric.ENCODING_CHECK_TIME_MS), anyLong());
-    verify(metricsHandler).setCustomMetric(eq(CustomReportMetric.UPLOAD_TIME_MS), anyLong());
+    verify(metricsHandler).setCustomMetric(eq(CustomMetricId.ENCODING_CHECK_TIME_MS), anyDouble());
+    verify(metricsHandler).setCustomMetric(eq(CustomMetricId.UPLOAD_TIME_MS), anyDouble());
 
   }
 


### PR DESCRIPTION
## What

[LPF-1453](https://dsdmoj.atlassian.net/browse/LPF-1453)

Add metrics for 

- Total Connections to the DB
- Active connections to the DB
- Idle connections to the DB
- Max connections
- Active utilisation (i.e. how much work is happening in the database)
- Total utilisation (i.e. how close are we to exhausting the total connections available)

They are exported at the end of the cronjob currently.
They are exported as the job "databaseHealth"

## Evidence
<img width="1461" height="363" alt="image" src="https://github.com/user-attachments/assets/10343feb-1557-431a-8ef1-f1c866ce9ae5" />


## Checklist

Before you ask people to review this PR:

- [x] Title follows the format `{type}({TICKET-NUMBER}): {brief description}`.   Example: `feat(ABC-123): add caching layer`
    - Type must be one of:
        - feat
        - fix
        - docs
        - chore
        - refactor
        - test
        - ci
        - build
        - perf
- [ ] Bump Helm chart version (if you have changed the Helm templates)
- [x] Tests should be passing: `./gradlew test` & `./gradlew integrationTest`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.


[LPF-1453]: https://dsdmoj.atlassian.net/browse/LPF-1453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ