### PR TITLE
chore: Update action versions dependabot misses

### DIFF
--- a/.github/cleanup_branch/action.yml
+++ b/.github/cleanup_branch/action.yml
@@ -23,7 +23,7 @@ runs:
       uses: ./.github/get_release_name_to_delete
 
     - name: Authenticate to the cluster
-      uses: ministryofjustice/laa-reusable-github-actions/.github/actions/authenticate_to_cluster@2aa2676c3cd9876ec7037ee8b3d729d0306cb7c6
+      uses: ministryofjustice/laa-reusable-github-actions/.github/actions/authenticate_to_cluster@718424912b7cac2b905764128f52ee7c99241507 # latest commit ID for this workflow file
       with:
         kube-cert: ${{ inputs.kube-cert }}
         kube-token: ${{ inputs.kube-token }}

--- a/.github/cleanup_branch/action.yml
+++ b/.github/cleanup_branch/action.yml
@@ -23,7 +23,7 @@ runs:
       uses: ./.github/get_release_name_to_delete
 
     - name: Authenticate to the cluster
-      uses: ministryofjustice/laa-reusable-github-actions/.github/actions/authenticate_to_cluster@718424912b7cac2b905764128f52ee7c99241507 # latest commit ID for this workflow file
+      uses: ministryofjustice/laa-reusable-github-actions/.github/actions/authenticate_to_cluster@a0bd8225ca8cc96e57a19223ce21f2ce7230833c # latest commit for repo
       with:
         kube-cert: ${{ inputs.kube-cert }}
         kube-token: ${{ inputs.kube-token }}

--- a/.github/deploy/action.yaml
+++ b/.github/deploy/action.yaml
@@ -31,7 +31,7 @@ runs:
   steps:
 
     - name: Authenticate to the cluster
-      uses: ministryofjustice/laa-reusable-github-actions/.github/actions/authenticate_to_cluster@2aa2676c3cd9876ec7037ee8b3d729d0306cb7c6
+      uses: ministryofjustice/laa-reusable-github-actions/.github/actions/authenticate_to_cluster@718424912b7cac2b905764128f52ee7c99241507 # latest commit ID for this workflow file
       with:
         kube-cert: ${{ inputs.kube-cert }}
         kube-token: ${{ inputs.kube-token }}
@@ -39,14 +39,14 @@ runs:
         kube-namespace: ${{ inputs.kube-namespace }}
 
     - name: Assume role in Cloud Platform
-      uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+      uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
       with:
         role-to-assume: ${{ inputs.ecr-role-to-assume }}
         aws-region: ${{ inputs.ecr-region }}
 
     - name: Docker login to ECR
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@183a1442edf41672e66566b7fc560e297a290896 # v2.1.1
+      uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6
       with:
         mask-password: 'true'
 

--- a/.github/deploy/action.yaml
+++ b/.github/deploy/action.yaml
@@ -31,7 +31,7 @@ runs:
   steps:
 
     - name: Authenticate to the cluster
-      uses: ministryofjustice/laa-reusable-github-actions/.github/actions/authenticate_to_cluster@718424912b7cac2b905764128f52ee7c99241507 # latest commit ID for this workflow file
+      uses: ministryofjustice/laa-reusable-github-actions/.github/actions/authenticate_to_cluster@a0bd8225ca8cc96e57a19223ce21f2ce7230833c # latest commit for repo
       with:
         kube-cert: ${{ inputs.kube-cert }}
         kube-token: ${{ inputs.kube-token }}

--- a/.github/deploy_branch/action.yml
+++ b/.github/deploy_branch/action.yml
@@ -46,7 +46,7 @@ runs:
       uses: ./.github/get_release_name
 
     - name: Authenticate to the cluster
-      uses: ministryofjustice/laa-reusable-github-actions/.github/actions/authenticate_to_cluster@718424912b7cac2b905764128f52ee7c99241507 # latest commit ID for this workflow file
+      uses: ministryofjustice/laa-reusable-github-actions/.github/actions/authenticate_to_cluster@a0bd8225ca8cc96e57a19223ce21f2ce7230833c # latest commit for repo
       with:
         kube-cert: ${{ inputs.kube-cert }}
         kube-token: ${{ inputs.kube-token }}

--- a/.github/deploy_branch/action.yml
+++ b/.github/deploy_branch/action.yml
@@ -39,14 +39,14 @@ runs:
   steps:
 
     - name: Checkout Github Repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Extract release name
       id: extract_release_name
       uses: ./.github/get_release_name
 
     - name: Authenticate to the cluster
-      uses: ministryofjustice/laa-reusable-github-actions/.github/actions/authenticate_to_cluster@2aa2676c3cd9876ec7037ee8b3d729d0306cb7c6
+      uses: ministryofjustice/laa-reusable-github-actions/.github/actions/authenticate_to_cluster@718424912b7cac2b905764128f52ee7c99241507 # latest commit ID for this workflow file
       with:
         kube-cert: ${{ inputs.kube-cert }}
         kube-token: ${{ inputs.kube-token }}
@@ -54,14 +54,14 @@ runs:
         kube-namespace: ${{ inputs.kube-namespace }}
 
     - name: Assume role in Cloud Platform
-      uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+      uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
       with:
         role-to-assume: ${{ inputs.ecr-role-to-assume }}
         aws-region: ${{ inputs.ecr-region }}
 
     - name: Docker login to ECR
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@183a1442edf41672e66566b7fc560e297a290896 # v2.1.1
+      uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6
       with:
         mask-password: 'true'
 

--- a/.github/get_release_name/action.yml
+++ b/.github/get_release_name/action.yml
@@ -13,7 +13,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout Github Repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - name: Extract branch name
       id: extract_branch
       shell: bash

--- a/.github/spotbugs-scan/action.yml
+++ b/.github/spotbugs-scan/action.yml
@@ -5,13 +5,13 @@ runs:
   using: 'composite'
   steps:
     - name: Set up JDK 25
-      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
       with:
         java-version: 25
         distribution: 'corretto'
 
     - name: Set up Gradle
-      uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+      uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
 
     - name: Run SpotBugs security scan and generate SARIF report
       run: |
@@ -20,7 +20,7 @@ runs:
       shell: bash
 
     - name: Upload SpotBugs results to GitHub Code Scanning
-      uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
+      uses: github/codeql-action/upload-sarif@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
       if: always()
       with:
         sarif_file: build/reports/spotbugs/main.sarif


### PR DESCRIPTION
## What

[Link to ticket](https://dsdmoj.atlassian.net/browse/LPF-XXX)

Dependabot doesn't update action versions inside the action sub-folders currently. Bring them up to date

## Evidence
- Attach any screenshots of a manual test or logs, or link to successful deployment
- Before & after the change if possible

## Checklist

Before you ask people to review this PR:

- [x] Title follows the format `{type}({TICKET-NUMBER}): {brief description}`.   Example: `feat(ABC-123): add caching layer`
    - Type must be one of:
        - feat
        - fix
        - docs
        - chore
        - refactor
        - test
        - ci
        - build
        - perf
- [x] Bump Helm chart version (if you have changed the Helm templates)
- [x] Tests should be passing: `./gradlew test` & `./gradlew integrationTest`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
