### PR TITLE
ci(LPF-1487): Add Secret scanning

### DIFF
--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -1,0 +1,282 @@
+name: Secret Scanning
+
+# ---------------------------------------------------------------------------
+# WHAT THIS DOES
+# ---------------------------------------------------------------------------
+# 1. On every PR / push to main  -> fast INCREMENTAL scan (just the new/changed
+#    commits) so contributors get quick feedback and PRs stay fast.
+# 2. On a weekly schedule (and whenever you trigger it manually) -> DEEP FULL
+#    scan of the entire repo + full git history, to catch anything that slipped
+#    through, was force-pushed, or was added before this workflow existed.
+# 3. workflow_dispatch lets you run either mode on demand, and choose branch/ref.
+# 4. Findings are uploaded as SARIF to the "Security > Code scanning" tab, and
+#    also kept as a downloadable artifact for 90 days.
+# ---------------------------------------------------------------------------
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    # Every Monday at 03:00 UTC.
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+    inputs:
+      scan_mode:
+        description: 'Scan mode'
+        required: true
+        default: 'full'
+        type: choice
+        options:
+          - full
+          - diff
+      ref:
+        description: 'Branch/tag/SHA to scan (defaults to current branch)'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  GITLEAKS_VERSION: '8.21.2'
+
+concurrency:
+  group: secret-scanning-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # =========================================================================
+  # JOB 1: Fast incremental scan — new/changed commits only.
+  # Runs on: pull_request, push to main, and manual dispatch with mode=diff
+  # =========================================================================
+  scan-diff:
+    name: Scan changed commits
+    if: >
+      github.event_name == 'pull_request' ||
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_dispatch' && inputs.scan_mode == 'diff')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.ref || github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        run: |
+          archive="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          checksums="gitleaks_${GITLEAKS_VERSION}_checksums.txt"
+          base_url="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}"
+
+          curl -fsSL "${base_url}/${archive}" -o "${archive}"
+          curl -fsSL "${base_url}/${checksums}" -o gitleaks_checksums.txt
+          grep " ${archive}$" gitleaks_checksums.txt > gitleaks.sha256
+          sha256sum -c gitleaks.sha256
+
+          tar -xzf "${archive}" gitleaks
+          sudo mv gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+
+      - name: Determine commit range
+        id: range
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "log_opts=${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            before="${{ github.event.before }}"
+            after="${{ github.event.after }}"
+            
+            if [ -z "$before" ] || [[ "$before" =~ ^0+$ ]] || ! git merge-base --is-ancestor "$before" "$after" 2>/dev/null; then
+              echo "log_opts=-1" >> "$GITHUB_OUTPUT"
+            else
+              echo "log_opts=${before}..${after}" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "log_opts=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run gitleaks (diff scan)
+        id: gitleaks
+        run: |
+          mkdir -p reports
+          log_opts="${{ steps.range.outputs.log_opts }}"
+          if [ -z "$log_opts" ]; then
+            # Manual dispatch with mode=diff but no clear range: fall back to
+            # scanning just the latest commit.
+            log_opts="-1"
+          fi
+
+          set +e
+          gitleaks detect \
+            --source . \
+            --log-opts="$log_opts" \
+            --report-format sarif \
+            --report-path reports/gitleaks.sarif \
+            --redact \
+            --verbose \
+            --exit-code 1
+          exit_code=$?
+          set -e
+
+          echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
+
+      - name: Check SARIF report exists
+        id: sarif_check
+        if: always()
+        run: |
+          if [ -f reports/gitleaks.sarif ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::No SARIF report found — gitleaks likely failed before producing output (see the 'Run gitleaks' step above). Skipping upload steps."
+          fi
+
+      - name: Upload SARIF to Security tab
+        if: always() && steps.sarif_check.outputs.exists == 'true'
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          sarif_file: reports/gitleaks.sarif
+
+      - name: Upload report artifact
+        if: always() && steps.sarif_check.outputs.exists == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: gitleaks-diff-report
+          path: reports/gitleaks.sarif
+          retention-days: 90
+
+      - name: Comment on PR if secrets found
+        if: steps.gitleaks.outputs.exit_code == '1' && github.event_name == 'pull_request'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: '🚨 **Potential secret(s) detected by Gitleaks.** Check the *Checks* tab and the *Security > Code scanning* tab for details. Please rotate any real credentials immediately and remove them from git history before merging.'
+            })
+
+      - name: Fail job if leaks were found or scan errored
+        if: steps.gitleaks.outputs.exit_code != '0'
+        run: |
+          echo "Gitleaks exited with code ${{ steps.gitleaks.outputs.exit_code }} — failing the job."
+          exit 1
+
+  # =========================================================================
+  # JOB 2: Deep full scan — entire repo + full git history.
+  # Runs on: weekly schedule, and manual dispatch with mode=full (default)
+  # =========================================================================
+  scan-full:
+    name: Scan full repository history
+    if: >
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && inputs.scan_mode == 'full')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout full history
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        run: |
+          archive="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          checksums="gitleaks_${GITLEAKS_VERSION}_checksums.txt"
+          base_url="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}"
+
+          curl -fsSL "${base_url}/${archive}" -o "${archive}"
+          curl -fsSL "${base_url}/${checksums}" -o gitleaks_checksums.txt
+          grep " ${archive}$" gitleaks_checksums.txt > gitleaks.sha256
+          sha256sum -c gitleaks.sha256
+
+          tar -xzf "${archive}" gitleaks
+          sudo mv gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+
+      - name: Run gitleaks (full repo + history scan)
+        id: gitleaks
+        run: |
+          mkdir -p reports
+
+          set +e
+          gitleaks detect \
+            --source . \
+            --report-format sarif \
+            --report-path reports/gitleaks.sarif \
+            --redact \
+            --verbose \
+            --exit-code 1
+          exit_code=$?
+          set -e
+
+          echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
+
+      - name: Check SARIF report exists
+        id: sarif_check
+        if: always()
+        run: |
+          if [ -f reports/gitleaks.sarif ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::No SARIF report found — gitleaks likely failed before producing output (see the 'Run gitleaks' step above). Skipping upload steps."
+          fi
+
+      - name: Upload SARIF to Security tab
+        if: always() && steps.sarif_check.outputs.exists == 'true'
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          sarif_file: reports/gitleaks.sarif
+
+      - name: Upload report artifact
+        if: always() && steps.sarif_check.outputs.exists == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: gitleaks-full-report
+          path: reports/gitleaks.sarif
+          retention-days: 90
+
+      - name: Check for existing open secret-scan issue
+        id: existing_issue
+        if: steps.gitleaks.outputs.exit_code == '1' && github.event_name == 'schedule'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'secret-scan'
+            });
+            core.setOutput('found', issues.length > 0 ? 'true' : 'false');
+
+      - name: File an issue if secrets found (scheduled runs only, deduped)
+        if: steps.gitleaks.outputs.exit_code == '1' && github.event_name == 'schedule' && steps.existing_issue.outputs.found == 'false'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `🚨 Weekly secret scan found potential leak(s) — ${new Date().toISOString().slice(0,10)}`,
+              body: 'The scheduled Gitleaks full-repo scan detected potential secrets. See the workflow run and the *Security > Code scanning* tab for details:\n\n' + `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}` + '\n\n_This issue will not be re-created while an open issue labelled `secret-scan` exists — close this one once resolved so future scans can re-alert if needed._',
+              labels: ['security', 'secret-scan']
+            })
+
+      - name: Fail job if leaks were found or scan errored
+        if: steps.gitleaks.outputs.exit_code != '0'
+        run: |
+          echo "Gitleaks exited with code ${{ steps.gitleaks.outputs.exit_code }} — failing the job."
+          exit 1

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,15 @@
+title = "gitleaks config"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Ignore UUIDs in test fixtures"
+
+paths = [
+    '''src/test/.*'''
+]
+
+regexes = [
+    '''[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'''
+]


### PR DESCRIPTION
## What

[LPF-1487](https://dsdmoj.atlassian.net/browse/LPF-1487)

Currently we have pre-commit hooks provided by hooks built by DevSecOps, that do credentials/secret scanning prior to commits. Only useful if developer has pre commit hooks enabled/installed. Even if enabled, commit hooks are easily bypassed using --no-verify as a commit argument. 

Took action by creating a Github workflow to enable secrets scanning on PRs but also full repo scanning on main + weekly scheduled scans, with the option of manual scans too.

.gitleaks.toml file added to specify allow-lists, false positives etc. Have currently added an ignore to UUIDs in text fixtures as it was picking these up from older commits

Githubs server side push protection should also block most secrets/credentials from getting through to remote

If a secret has been detected, dev must rebase to remove the affected commit

## Evidence
```
    ○
    │╲
    │ ○
    ○ ░
    ░    gitleaks

Finding:     add a test secret
password = REDACTED
Secret:      REDACTED
RuleID:      generic-api-key
Entropy:     5.000000
File:        README.md
Line:        481
Commit:      7ae170f95c826eee9044c4892854b70eb4314e97
Author:      Masuk Kazi
Email:       90158744+masuk-kazi98@users.noreply.github.com
Date:        2026-07-02T16:27:41Z
Fingerprint: 7ae170f95c826eee9044c4892854b70eb4314e97:README.md:generic-api-key:481

4:29PM INF 95 commits scanned.
4:29PM INF scan completed in 96.8ms
4:29PM WRN leaks found: 1
```

## Checklist

Before you ask people to review this PR:

- [ ] Title follows the format `{type}({TICKET-NUMBER}): {brief description}`.   Example: `feat(ABC-123): add caching layer`
    - Type must be one of:
        - feat
        - fix
        - docs
        - chore
        - refactor
        - test
        - ci
        - build
        - perf
- [ ] Bump Helm chart version (if you have changed the Helm templates)
- [ ] Tests should be passing: `./gradlew test` & `./gradlew integrationTest`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.


[LPF-1487]: https://dsdmoj.atlassian.net/browse/LPF-1487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ