### PR TITLE
fix(LPF-1538): Harden container defaults

### DIFF
--- a/.helm/data-claims-reporting-service/Chart.yaml
+++ b/.helm/data-claims-reporting-service/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.5
+version: 1.4.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/.helm/data-claims-reporting-service/templates/cronjob.yaml
+++ b/.helm/data-claims-reporting-service/templates/cronjob.yaml
@@ -27,4 +27,14 @@ spec:
                 {{ include "data-claims-reporting.dbConnectionDetails" . | nindent 16 }}
               resources:
                 {{ toYaml .Values.resources | nindent 16 }}
+              securityContext:
+                runAsUser: 1001
+                runAsGroup: 1001
+                capabilities:
+                  drop:
+                    - ALL
+                runAsNonRoot: true
+                allowPrivilegeEscalation: false
+                seccompProfile:
+                  type: RuntimeDefault
           restartPolicy: OnFailure

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /opt/laa-data-reporting-service/claims-reporting/
 COPY /build/libs/laa-data-claims-reporting-service-1.0.0.jar app.jar
 
 # Create a group and non-root user
-RUN addgroup -S appgroup && adduser -u 1001 -S appuser -G appgroup
+RUN addgroup -g 1001 -S appgroup && adduser -u 1001 -S appuser -G appgroup
 
 # Set the default user
 USER 1001


### PR DESCRIPTION

## What

[LPF-1538](https://dsdmoj.atlassian.net/browse/LPF-1538)

Amended dockerfile to create group with explicit group id (1001), and added securityContext values in cronjob.yaml for the container.
This was done to explicitly harden default permissions for the containers so that we have more control over the security of our containers even if cloud platform values change.

## Evidence
| Tests passing after container defaults applied | 
| ------| 
| <img width="2881" height="569" alt="image" src="https://github.com/user-attachments/assets/832e0061-de77-4072-8b5e-361ea58b3170" /> |

| Passing integration tests locally | 
| ------ |
| <img width="1767" height="733" alt="image" src="https://github.com/user-attachments/assets/d051148c-9533-4b6d-8d55-82aed24c2e6e" /> |

## Checklist

Before you ask people to review this PR:

- [X] Title follows the format `{type}({TICKET-NUMBER}): {brief description}`.   Example: `feat(ABC-123): add caching layer`
    - Type must be one of:
        - feat
        - fix
        - docs
        - chore
        - refactor
        - test
        - ci
        - build
        - perf
- [X] Bump Helm chart version (if you have changed the Helm templates)
- [X] Tests should be passing: `./gradlew test` & `./gradlew integrationTest`
- [X] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [X] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [X] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [X] You should have checked that the commit messages say why the change was made.


[LPF-1538]: https://dsdmoj.atlassian.net/browse/LPF-1538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ