### PR TITLE
feat(LPF-1493): Fix aggregation logic REP012

### DIFF
--- a/src/integrationTest/resources/expected_csv_files/reports/daily/report_012_2025-11-21.csv
+++ b/src/integrationTest/resources/expected_csv_files/reports/daily/report_012_2025-11-21.csv
@@ -1,4 +1,4 @@
 "Provider office account number","Submission month","Area of law","Original submission value","Date submission was uploaded"
-OA001,APR-2025,CRIME_LOWER,17704.00,21/11/2025
+OA001,APR-2025,CRIME_LOWER,6200.00,21/11/2025
 OA001,MAY-2025,CRIME_LOWER,0.00,21/11/2025
 OA001,MAY-2025,LEGAL_HELP,4500.00,21/11/2025

--- a/src/main/resources/db/migration/schema/V56__rep012_fix_aggregation_for_amendments.sql
+++ b/src/main/resources/db/migration/schema/V56__rep012_fix_aggregation_for_amendments.sql
@@ -1,0 +1,94 @@
+DROP MATERIALIZED VIEW IF EXISTS mvw_report_012;
+
+CREATE MATERIALIZED VIEW mvw_report_012 AS
+WITH submission_normalised AS (
+    SELECT
+        s.id AS submission_id,
+        s.office_account_number,
+        s.area_of_law,
+        s.submission_period,
+        s.status,
+        s.created_on,
+        CASE
+            WHEN s.submission_period ~ '^\d{4}-\d{2}-\d{2}$'
+                THEN TO_DATE(s.submission_period, 'YYYY-MM-DD')
+            WHEN s.submission_period ~ '^\d{4}-\d{2}$'
+                THEN TO_DATE(s.submission_period || '-01', 'YYYY-MM-DD')
+            WHEN s.submission_period ~ '^[A-Za-z]{3}-\d{4}$'
+                THEN TO_DATE(UPPER(s.submission_period), 'MON-YYYY')
+            ELSE NULL
+        END AS submission_period_date
+    FROM claims.submission AS s
+),
+eligible_submissions AS (
+    SELECT
+        sn.submission_id,
+        sn.office_account_number,
+        sn.area_of_law,
+        sn.submission_period_date,
+        sn.created_on,
+        ROW_NUMBER() OVER (
+            PARTITION BY
+                sn.office_account_number,
+                sn.area_of_law,
+                sn.submission_period_date
+            ORDER BY
+                sn.created_on DESC,
+                sn.submission_id DESC
+        ) AS rn
+    FROM submission_normalised AS sn
+    WHERE sn.status = 'VALIDATION_SUCCEEDED'
+      AND sn.area_of_law IN ('LEGAL_HELP', 'CRIME_LOWER', 'MEDIATION')
+      AND sn.submission_period_date IS NOT NULL
+),
+original_submissions AS (
+    SELECT *
+    FROM eligible_submissions
+    WHERE rn = 1
+),
+valid_claim_counts AS (
+    SELECT
+        c.submission_id,
+        COUNT(*) FILTER (WHERE c.status = 'VALID') AS valid_claim_count
+    FROM claims.claim AS c
+    WHERE c.submission_id IN (SELECT submission_id FROM original_submissions)
+    GROUP BY c.submission_id
+),
+selected_claim_fees AS (
+    SELECT
+        c.id AS claim_id,
+        c.submission_id,
+        COALESCE(calc_latest.total_amount, 0) AS selected_total_amount
+    FROM claims.claim AS c
+    LEFT JOIN LATERAL (
+        SELECT cfd.total_amount
+        FROM claims.calculated_fee_detail AS cfd
+        WHERE cfd.claim_id = c.id
+        ORDER BY
+            COALESCE(cfd.updated_on, cfd.created_on) DESC NULLS LAST,
+            cfd.id DESC
+        LIMIT 1
+    ) AS calc_latest ON TRUE
+    WHERE c.submission_id IN (SELECT submission_id FROM original_submissions)
+),
+fee_totals AS (
+    SELECT
+        scf.submission_id,
+        SUM(scf.selected_total_amount) AS total_fee
+    FROM selected_claim_fees AS scf
+    GROUP BY scf.submission_id
+)
+SELECT
+    os.office_account_number                                  AS "Provider office account number",
+    TO_CHAR(os.submission_period_date, 'MON-YYYY')            AS "Submission month",
+    os.area_of_law                                            AS "Area of law",
+    COALESCE(
+            ROUND(ft.total_fee, 2),
+            0::NUMERIC(18, 2)
+    ) AS "Original submission value",
+    TO_CHAR(os.created_on AT TIME ZONE 'Europe/London', 'DD/MM/YYYY') AS "Date submission was uploaded"
+FROM original_submissions AS os
+         LEFT JOIN valid_claim_counts AS vcc
+                   ON vcc.submission_id = os.submission_id
+         LEFT JOIN fee_totals AS ft
+                   ON ft.submission_id = os.submission_id;


### PR DESCRIPTION
## What

[LPF-1493](https://dsdmoj.atlassian.net/browse/LPF-1493)

- We still need one total per submission, so some summing is required.
- The bug was that we were summing all calculated fee rows, including multiple amendment rows for the same claim.
- The fix changes that to one fee value per claim first (latest row), then sums across claims in the submission.
- If we remove summing entirely, we would only return one claim’s value, which would understate normal multi-claim submissions.

## Evidence
- Attach any screenshots of a manual test or logs, or link to successful deployment
- Before & after the change if possible

## Checklist

Before you ask people to review this PR:

- [ ] Title follows the format `{type}({TICKET-NUMBER}): {brief description}`.   Example: `feat(ABC-123): add caching layer`
    - Type must be one of:
        - feat
        - fix
        - docs
        - chore
        - refactor
        - test
        - ci
        - build
        - perf
- [ ] Bump Helm chart version (if you have changed the Helm templates)
- [ ] Tests should be passing: `./gradlew test` & `./gradlew integrationTest`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.


[LPF-1493]: https://dsdmoj.atlassian.net/browse/LPF-1493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ