### PR TITLE
ci(LPF-1549): get dependabot to use fix not chore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,24 +5,15 @@
 
 version: 2
 
-registries:
-  spring-boot-common-github-packages:
-    type: maven-repository
-    url: https://maven.pkg.github.com/ministryofjustice/laa-spring-boot-common
-    username: ${{ secrets.TOKEN_USER }}
-    password: ${{ secrets.DEPENDABOT_PAT }}
-
 updates:
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "chore(bot)"
+      prefix: "fix(bot)"
     cooldown:
       default-days: 3
-    registries:
-      - spring-boot-common-github-packages
     groups:
       gradle-updates:
         exclude-patterns:

--- a/.github/workflows/pr-title-validation.yml
+++ b/.github/workflows/pr-title-validation.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Checking PR title: $TITLE"
 
           if echo "$TITLE" | grep -Eq \
-            '^((feat|fix|docs|refactor|test|ci|build|perf)\([A-Z]+-[0-9]+\)!?: .+)$|^chore(.*): .+$'; then
+            '^((feat|fix|docs|refactor|test|ci|build|perf)\([A-Z]+-[0-9]+\)!?: .+)$|^chore(.*): .+$|^fix\(bot\): .+$'; then
             echo "✅ PR title format is valid"
           else
             echo "❌ Invalid PR title format"


### PR DESCRIPTION
## What

[Link to ticket](https://dsdmoj.atlassian.net/browse/LPF-1549)

Move dependabot to use fix for gradle issues in line with release approach
Update PR validation to match
Attempt to fix Dependabot error: Remove the old package manager for laa common - its moved and so cannot be reached anymore

## Evidence
Can't run dependabot outside main

## Checklist

Before you ask people to review this PR:

- [x] Title follows the format `{type}({TICKET-NUMBER}): {brief description}`.   Example: `feat(ABC-123): add caching layer`
    - Type must be one of:
        - feat
        - fix
        - docs
        - chore
        - refactor
        - test
        - ci
        - build
        - perf
- [ ] Bump Helm chart version (if you have changed the Helm templates)
- [x] Tests should be passing: `./gradlew test` & `./gradlew integrationTest`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
