### PR TITLE
chore(LPF-1574): Split out deployments to use env specific ECRs

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -146,18 +146,21 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-  build-push-docker:
-    name: build and push docker image
+  # Image is built and pushed per-environment (below) so each environment's own ECR is used.
+  deploy-uat:
     runs-on: ubuntu-latest
     needs:
       - build-test
+      - vulnerability-scan-app
       - vulnerability-scan-docker
+    environment: uat
     permissions:
       id-token: write
       contents: read
-    steps:
 
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Download JAR artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -170,11 +173,12 @@ jobs:
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           role-to-assume: ${{ secrets.ECR_ROLE_TO_ASSUME }}
-          aws-region: ${{  vars.ECR_REGION }}
+          aws-region: ${{ vars.ECR_REGION }}
 
       - name: Login to ECR
         uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6
         id: login-ecr
+
       - name: Build and push a Docker image for claims-reporting
         run: |
           DOCKER_BUILDKIT=0 docker build --no-cache -t $REGISTRY/$REPOSITORY:$IMAGE_TAG ./
@@ -183,21 +187,6 @@ jobs:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: ${{ vars.ECR_REPOSITORY }}
           IMAGE_TAG: ${{ github.sha }}
-
-  deploy-uat:
-    runs-on: ubuntu-latest
-    needs:
-      - build-push-docker
-      - vulnerability-scan-app
-      - vulnerability-scan-docker
-    environment: uat
-    permissions:
-      id-token: write
-      contents: read
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Deploy UAT branch
         id: deploy_uat_branch
@@ -216,7 +205,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs:
-      - build-push-docker
+      - build-test
       - vulnerability-scan-app
       - vulnerability-scan-docker
     environment: staging
@@ -228,6 +217,32 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Download JAR artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: service-jar
+          path: build/libs/
+
+        # ---------- AWS auth (OIDC) ----------
+      - name: Configure AWS creds
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: ${{ secrets.ECR_ROLE_TO_ASSUME }}
+          aws-region: ${{ vars.ECR_REGION }}
+
+      - name: Login to ECR
+        uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6
+        id: login-ecr
+
+      - name: Build and push a Docker image for claims-reporting
+        run: |
+          DOCKER_BUILDKIT=0 docker build --no-cache -t $REGISTRY/$REPOSITORY:$IMAGE_TAG ./
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: ${{ vars.ECR_REPOSITORY }}
+          IMAGE_TAG: ${{ github.sha }}
 
       - name: Deploy staging
         id: deploy_staging
@@ -255,6 +270,32 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Download JAR artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: service-jar
+          path: build/libs/
+
+        # ---------- AWS auth (OIDC) ----------
+      - name: Configure AWS creds
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: ${{ secrets.ECR_ROLE_TO_ASSUME }}
+          aws-region: ${{ vars.ECR_REGION }}
+
+      - name: Login to ECR
+        uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6
+        id: login-ecr
+
+      - name: Build and push a Docker image for claims-reporting
+        run: |
+          DOCKER_BUILDKIT=0 docker build --no-cache -t $REGISTRY/$REPOSITORY:$IMAGE_TAG ./
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: ${{ vars.ECR_REPOSITORY }}
+          IMAGE_TAG: ${{ github.sha }}
 
       - name: Deploy production
         id: deploy_production

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build-test:
+  build-and-run-tests:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -80,7 +80,7 @@ jobs:
   vulnerability-scan-app:
     runs-on: ubuntu-latest
     needs:
-      - build-test
+      - build-and-run-tests
     permissions:
       contents: read
     env:
@@ -100,7 +100,7 @@ jobs:
   vulnerability-scan-docker:
     runs-on: ubuntu-latest
     needs:
-      - build-test
+      - build-and-run-tests
     permissions:
       contents: read
     env:
@@ -132,7 +132,7 @@ jobs:
   
   spotbugs-scan:
     runs-on: ubuntu-latest
-    needs: build-test
+    needs: build-and-run-tests
     permissions:
       contents: read
       security-events: write
@@ -150,7 +150,7 @@ jobs:
   deploy-uat:
     runs-on: ubuntu-latest
     needs:
-      - build-test
+      - build-and-run-tests
       - vulnerability-scan-app
       - vulnerability-scan-docker
     environment: uat
@@ -205,7 +205,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs:
-      - build-test
+      - build-and-run-tests
       - vulnerability-scan-app
       - vulnerability-scan-docker
     environment: staging

--- a/build.gradle
+++ b/build.gradle
@@ -94,6 +94,7 @@ dependencies {
     implementation 'io.netty:netty-codec-compression:4.2.17.Final'
     implementation 'io.netty:netty-codec-http:4.2.17.Final'
     implementation 'io.netty:netty-codec-http2:4.2.17.Final'
+    implementation 'io.netty:netty-handler:4.2.17.Final'
     // Need until AWS SDK reaches 5.4.3 or higher
     implementation 'org.apache.httpcomponents.core5:httpcore5-h2:5.4.3'
 


### PR DESCRIPTION
## What

[Link to ticket](https://dsdmoj.atlassian.net/browse/LPF-1574)

Describe what you did and why.

Part of the DCRS ECR split ([cloud-platform-environments#45024](https://github.com/ministryofjustice/cloud-platform-environments/pull/45024), [#45025](https://github.com/ministryofjustice/cloud-platform-environments/pull/45025), [#45026](https://github.com/ministryofjustice/cloud-platform-environments/pull/45026)). CP now provisions three dedicated ECRs (laa-data-claims-reporting-service-uat/-staging/-prod), each with its own GitHub Environment-scoped ECR_REPOSITORY/ECR_REGION/ECR_ROLE_TO_ASSUME. This app repo's workflow needed to catch up so that images actually land in the correct per-environment ECR, rather than one shared repository, matching the pattern already used in payforlegalaid.

- Removed the standalone build-push-docker job, which ran outside any GitHub Environment context and always pushed to the repo-level (shared) ECR_REPOSITORY.
- Moved the build+push steps (download JAR artifact → configure AWS creds → ECR login → build & push image) into each of deploy-uat, deploy-staging, and deploy-production, inside their existing environment: blocks, so vars.ECR_REPOSITORY/vars.ECR_REGION/secrets.ECR_ROLE_TO_ASSUME now resolve to that environment's own scoped values.
- Updated deploy-staging's needs: from the removed build-push-docker job to build-test.
- Minor whitespace fix (aws-region: ${{ vars.ECR_REGION }}).

## Evidence
- Attach any screenshots of a manual test or logs, or link to successful deployment
- Before & after the change if possible

## Checklist

Before you ask people to review this PR:

- [ ] Title follows the format `{type}({TICKET-NUMBER}): {brief description}`.   Example: `feat(ABC-123): add caching layer`
    - Type must be one of:
        - feat
        - fix
        - docs
        - chore
        - refactor
        - test
        - ci
        - build
        - perf
- [ ] Bump Helm chart version (if you have changed the Helm templates)
- [ ] Tests should be passing: `./gradlew test` & `./gradlew integrationTest`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
