### PR TITLE
chore(LPF-000): cleanup old snyk overrides 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,35 +79,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-micrometer-tracing-brave'
     implementation 'io.micrometer:micrometer-tracing-bridge-brave'
 
-    // Snyk vulns
-    implementation 'ch.qos.logback:logback-core:1.6.3'
-    implementation 'ch.qos.logback:logback-classic:1.6.3' // override until fix available
-    implementation 'org.apache.tomcat.embed:tomcat-embed-core:11.0.25'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.22.2'
-    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.22'
-    // The 3.x Jacksons MUST be kept in sync or they will break the build.
-    implementation 'tools.jackson.core:jackson-databind:3.2.2'
-    implementation 'tools.jackson.core:jackson-core:3.2.2'
-    implementation 'tools.jackson.dataformat:jackson-dataformat-csv:3.2.2' // Until Spring Boot gets to 3.1.5
-    // Need until AWS SDK reaches 4.2.16.Final or higher
-    implementation 'io.netty:netty-codec:4.2.17.Final'
-    implementation 'io.netty:netty-codec-compression:4.2.17.Final'
-    implementation 'io.netty:netty-codec-http:4.2.17.Final'
-    implementation 'io.netty:netty-codec-http2:4.2.17.Final'
-    implementation 'io.netty:netty-handler:4.2.17.Final'
-    // Need until AWS SDK reaches 5.4.3 or higher
-    implementation 'org.apache.httpcomponents.core5:httpcore5-h2:5.4.3'
-    // Need until Spring Boot reaches 1.17.1 or higher
-    implementation 'io.micrometer:micrometer-core:1.17.1'
-    // Need until Spring Boot reaches 1.7.1 or higher
-    implementation 'io.micrometer:micrometer-tracing-bridge-brave:1.7.1'
-    // Need until Spring Boot reaches 7.0.9 or higher
-    implementation 'org.springframework:spring-beans:7.0.9'
-    implementation 'org.springframework:spring-expression:7.0.9'
+    implementation 'tools.jackson.dataformat:jackson-dataformat-csv'
 
     runtimeOnly 'org.springframework.boot:spring-boot-starter-flyway'
-    runtimeOnly 'org.postgresql:postgresql:42.7.13' // override until LAA plugin updated
-    runtimeOnly "org.flywaydb:flyway-database-postgresql:13.3.0" // Override until Spring updates
+    runtimeOnly 'org.postgresql:postgresql'
+    runtimeOnly "org.flywaydb:flyway-database-postgresql"
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-actuator-test'


### PR DESCRIPTION
## What

[Link to ticket](https://dsdmoj.atlassian.net/browse/LPF-XXX)

Remove old overrides that were in place due to Spring Boot 4.1.0 being out of date. Spring Boot 4.1.1 resolves these themselves so it is prudent to let Spring Boot manage them.

## Evidence
Snyk pipleine passes
https://github.com/ministryofjustice/laa-data-claims-reporting-service/actions/runs/33081474431

## Checklist

Before you ask people to review this PR:

- [ ] Title follows the format `{type}({TICKET-NUMBER}): {brief description}`.   Example: `feat(ABC-123): add caching layer`
    - Type must be one of:
        - feat
        - fix
        - docs
        - chore
        - refactor
        - test
        - ci
        - build
        - perf
- [ ] Bump Helm chart version (if you have changed the Helm templates)
- [ ] Tests should be passing: `./gradlew test` & `./gradlew integrationTest`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
